### PR TITLE
Typing

### DIFF
--- a/pyonfx/__init__.py
+++ b/pyonfx/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# flake8: noqa
 
 from .font_utility import Font
 from .ass_core import Ass, Meta, Style, Line, Word, Syllable, Char

--- a/pyonfx/ass_core.py
+++ b/pyonfx/ass_core.py
@@ -22,7 +22,7 @@ import sys
 import time
 import copy
 import subprocess
-from typing import List, Tuple, Union, Optional
+from typing import Dict, List, Tuple, Union, Optional
 
 from .font_utility import Font
 from .convert import Convert
@@ -437,7 +437,9 @@ class Ass:
         self.__plines = 0
         self.__ptime = time.time()
 
-        self.meta, self.styles, self.lines = Meta(), {}, []
+        self.meta: Meta = Meta()
+        self.styles: Dict[str, Style] = {}
+        self.lines: List[Line] = []
         # Getting absolute sub file path
         dirname = os.path.dirname(os.path.abspath(sys.argv[0]))
         if not os.path.isabs(path_input):
@@ -1144,7 +1146,7 @@ class Ass:
                     else lines_by_styles[style][li + 1].start_time - line.end_time
                 )
 
-    def get_data(self) -> Tuple[Meta, Style, List[Line]]:
+    def get_data(self) -> Tuple[Meta, Dict[str, Style], List[Line]]:
         """Utility function to retrieve easily meta styles and lines.
 
         Returns:

--- a/pyonfx/ass_core.py
+++ b/pyonfx/ass_core.py
@@ -49,7 +49,7 @@ class Meta:
     audio: str
     video: str
 
-    def __repr__(self):
+    def __str__(self):
         return pretty_print(self)
 
 
@@ -114,7 +114,7 @@ class Style:
     margin_v: int
     encoding: int
 
-    def __repr__(self):
+    def __str__(self):
         return pretty_print(self)
 
 
@@ -171,7 +171,7 @@ class Char:
     middle: float
     bottom: float
 
-    def __repr__(self):
+    def __str__(self):
         return pretty_print(self)
 
 
@@ -227,7 +227,7 @@ class Syllable:
     middle: float
     bottom: float
 
-    def __repr__(self):
+    def __str__(self):
         return pretty_print(self)
 
 
@@ -277,7 +277,7 @@ class Word:
     middle: float
     bottom: float
 
-    def __repr__(self):
+    def __str__(self):
         return pretty_print(self)
 
 
@@ -359,7 +359,7 @@ class Line:
     syls: List[Syllable]
     chars: List[Char]
 
-    def __repr__(self):
+    def __str__(self):
         return pretty_print(self)
 
     def copy(self) -> Line:

--- a/pyonfx/ass_core.py
+++ b/pyonfx/ass_core.py
@@ -440,6 +440,7 @@ class Ass:
         self.meta: Meta = Meta()
         self.styles: Dict[str, Style] = {}
         self.lines: List[Line] = []
+
         # Getting absolute sub file path
         dirname = os.path.dirname(os.path.abspath(sys.argv[0]))
         if not os.path.isabs(path_input):

--- a/pyonfx/ass_core.py
+++ b/pyonfx/ass_core.py
@@ -138,10 +138,10 @@ class Char:
         postspace (int): Char free space after text.
         width (float): Char text width.
         height (float): Char text height.
-        ascent (float): Line font ascent (*).
-        descent (float): Line font descent (*).
-        internal_leading (float): Line font internal lead (*).
-        external_leading (float): Line font external lead (*).
+        ascent (float): Font ascent (*).
+        descent (float): Font descent (*).
+        internal_leading (float): Font internal lead (*).
+        external_leading (float): Font external lead (*).
         x (float): Char text position horizontal (depends on alignment).
         y (float): Char text position vertical (depends on alignment).
         left (float): Char text position left.

--- a/pyonfx/ass_core.py
+++ b/pyonfx/ass_core.py
@@ -203,10 +203,10 @@ class Syllable:
         postspace (int): Syllable free space after text.
         width (float): Syllable text width.
         height (float): Syllable text height.
-        ascent (float): Line font ascent (*).
-        descent (float): Line font descent (*).
-        internal_leading (float): Line font internal lead (*).
-        external_leading (float): Line font external lead (*).
+        ascent (float): Font ascent (*).
+        descent (float): Font descent (*).
+        internal_leading (float): Font internal lead (*).
+        external_leading (float): Font external lead (*).
         x (float): Syllable text position horizontal (depends on alignment).
         y (float): Syllable text position vertical (depends on alignment).
         left (float): Syllable text position left.
@@ -264,10 +264,10 @@ class Word:
         postspace (int): Word free space after text.
         width (float): Word text width.
         height (float): Word text height.
-        ascent (float): Line font ascent (*).
-        descent (float): Line font descent (*).
-        internal_leading (float): Line font internal lead (*).
-        external_leading (float): Line font external lead (*).
+        ascent (float): Font ascent (*).
+        descent (float): Font descent (*).
+        internal_leading (float): Font internal lead (*).
+        external_leading (float): Font external lead (*).
         x (float): Word text position horizontal (depends on alignment).
         y (float): Word text position vertical (depends on alignment).
         left (float): Word text position left.
@@ -331,10 +331,10 @@ class Line:
         text (str): Line stripped text (no tags).
         width (float): Line text width (*).
         height (float): Line text height (*).
-        ascent (float): Line font ascent (*).
-        descent (float): Line font descent (*).
-        internal_leading (float): Line font internal lead (*).
-        external_leading (float): Line font external lead (*).
+        ascent (float): Font ascent (*).
+        descent (float): Font descent (*).
+        internal_leading (float): Font internal lead (*).
+        external_leading (float): Font external lead (*).
         x (float): Line text position horizontal (depends on alignment) (*).
         y (float): Line text position vertical (depends on alignment) (*).
         left (float): Line text position left (*).

--- a/pyonfx/ass_core.py
+++ b/pyonfx/ass_core.py
@@ -1237,7 +1237,8 @@ class Ass:
         self, video_path: str = "", video_start: str = "", full_screen: bool = False
     ) -> int:
         """Open the output (specified in self.path_output) in softsub with the MPV player.
-        To utilize this function, MPV player is required. Additionally if you're on Windows, MPV must be in the PATH (check https://pyonfx.readthedocs.io/en/latest/quick%20start.html#installation-extra-step).
+        To utilize this function, MPV player is required. Additionally if you're on Windows,
+        MPV must be in the PATH (check https://pyonfx.readthedocs.io/en/latest/quick%20start.html#installation-extra-step).
 
         This is one of the fastest way to reproduce your output in a comfortable way.
 

--- a/pyonfx/ass_core.py
+++ b/pyonfx/ass_core.py
@@ -138,6 +138,10 @@ class Char:
         postspace (int): Char free space after text.
         width (float): Char text width.
         height (float): Char text height.
+        ascent (float): Line font ascent (*).
+        descent (float): Line font descent (*).
+        internal_leading (float): Line font internal lead (*).
+        external_leading (float): Line font external lead (*).
         x (float): Char text position horizontal (depends on alignment).
         y (float): Char text position vertical (depends on alignment).
         left (float): Char text position left.
@@ -162,6 +166,10 @@ class Char:
     postspace: int
     width: float
     height: float
+    ascent: float
+    descent: float
+    internal_leading: float
+    external_leading: float
     x: float
     y: float
     left: float
@@ -195,6 +203,10 @@ class Syllable:
         postspace (int): Syllable free space after text.
         width (float): Syllable text width.
         height (float): Syllable text height.
+        ascent (float): Line font ascent (*).
+        descent (float): Line font descent (*).
+        internal_leading (float): Line font internal lead (*).
+        external_leading (float): Line font external lead (*).
         x (float): Syllable text position horizontal (depends on alignment).
         y (float): Syllable text position vertical (depends on alignment).
         left (float): Syllable text position left.
@@ -218,6 +230,10 @@ class Syllable:
     postspace: int
     width: float
     height: float
+    ascent: float
+    descent: float
+    internal_leading: float
+    external_leading: float
     x: float
     y: float
     left: float
@@ -248,6 +264,10 @@ class Word:
         postspace (int): Word free space after text.
         width (float): Word text width.
         height (float): Word text height.
+        ascent (float): Line font ascent (*).
+        descent (float): Line font descent (*).
+        internal_leading (float): Line font internal lead (*).
+        external_leading (float): Line font external lead (*).
         x (float): Word text position horizontal (depends on alignment).
         y (float): Word text position vertical (depends on alignment).
         left (float): Word text position left.
@@ -268,6 +288,10 @@ class Word:
     postspace: int
     width: float
     height: float
+    ascent: float
+    descent: float
+    internal_leading: float
+    external_leading: float
     x: float
     y: float
     left: float

--- a/pyonfx/convert.py
+++ b/pyonfx/convert.py
@@ -28,8 +28,12 @@ if TYPE_CHECKING:
     from .ass_core import Line, Word, Syllable, Char
     from .shape import Shape
 
-# A simple NamedTuple to represent pixels
-Pixel = NamedTuple("Pixel", [("x", float), ("y", float), ("alpha", int)])
+
+class Pixel(NamedTuple):
+    """A simple NamedTuple to represent pixels"""
+    x: float
+    y: float
+    alpha: int
 
 
 class ColorModel(Enum):

--- a/pyonfx/convert.py
+++ b/pyonfx/convert.py
@@ -76,20 +76,10 @@ class Convert:
         """
         # Milliseconds?
         if type(ass_ms) is int and ass_ms >= 0:
-            return "{:d}:{:02d}:{:02d}.{:02d}".format(
-                math.floor(ass_ms / 3600000) % 10,
-                math.floor(ass_ms % 3600000 / 60000),
-                math.floor(ass_ms % 60000 / 1000),
-                math.floor(ass_ms % 1000 / 10),
-            )
+            return Convert.timems_to_assts(ass_ms)
         # ASS timestamp?
         elif type(ass_ms) is str and re.match(r"^\d:\d+:\d+\.\d+$", ass_ms):
-            return (
-                int(ass_ms[0]) * 3600000
-                + int(ass_ms[2:4]) * 60000
-                + int(ass_ms[5:7]) * 1000
-                + int(ass_ms[8:10]) * 10
-            )
+            return Convert.assts_to_timems(ass_ms)
         else:
             raise ValueError("Milliseconds or ASS timestamp expected")
 

--- a/pyonfx/convert.py
+++ b/pyonfx/convert.py
@@ -65,11 +65,21 @@ class Convert:
             If milliseconds -> ASS timestamp, else if ASS timestamp -> milliseconds, else ValueError will be raised.
         """
         # Milliseconds?
-        if isinstance(ass_ms, int) and ass_ms >= 0:
-            return Convert.timems_to_assts(ass_ms)
+        if type(ass_ms) is int and ass_ms >= 0:
+            return "{:d}:{:02d}:{:02d}.{:02d}".format(
+                math.floor(ass_ms / 3600000) % 10,
+                math.floor(ass_ms % 3600000 / 60000),
+                math.floor(ass_ms % 60000 / 1000),
+                math.floor(ass_ms % 1000 / 10),
+            )
         # ASS timestamp?
-        elif isinstance(ass_ms, str) and re.match(r"^\d:\d+:\d+\.\d+$", ass_ms):
-            return Convert.assts_to_timems(ass_ms)
+        elif type(ass_ms) is str and re.match(r"^\d:\d+:\d+\.\d+$", ass_ms):
+            return (
+                int(ass_ms[0]) * 3600000
+                + int(ass_ms[2:4]) * 60000
+                + int(ass_ms[5:7]) * 1000
+                + int(ass_ms[8:10]) * 10
+            )
         else:
             raise ValueError("Milliseconds or ASS timestamp expected")
 

--- a/pyonfx/convert.py
+++ b/pyonfx/convert.py
@@ -20,7 +20,7 @@ import re
 import math
 import colorsys
 from enum import Enum
-from typing import List, NamedTuple, Tuple, Union, TYPE_CHECKING
+from typing import Any, List, NamedTuple, NoReturn, Optional, Tuple, Union, TYPE_CHECKING
 
 from .font_utility import Font
 
@@ -113,7 +113,7 @@ class Convert:
             ) from e
 
     @staticmethod
-    def alpha_dec_to_ass(alpha_dec: Union[int, float]) -> str:
+    def alpha_dec_to_ass(alpha_dec: float) -> str:
         """Converts from decimal value to corresponding ASS alpha string.
 
         Parameters:
@@ -147,17 +147,8 @@ class Convert:
         c: Union[
             str,
             Union[
-                Tuple[
-                    Union[int, float],
-                    Union[int, float],
-                    Union[int, float],
-                ],
-                Tuple[
-                    Union[int, float],
-                    Union[int, float],
-                    Union[int, float],
-                    Union[int, float],
-                ],
+                Tuple[float, float, float],
+                Tuple[float, float, float, float],
             ],
         ],
         input_format: ColorModel,
@@ -165,8 +156,6 @@ class Convert:
         round_output: bool = True,
     ) -> Union[
         str,
-        Tuple[int, int, int],
-        Tuple[int, int, int, int],
         Tuple[float, float, float],
         Tuple[float, float, float, float],
     ]:
@@ -312,7 +301,7 @@ class Convert:
     @staticmethod
     def color_rgb_to_ass(
         color_rgb: Union[
-            str, Tuple[Union[int, float], Union[int, float], Union[int, float]]
+            str, Tuple[float, float, float]
         ]
     ) -> str:
         """Converts from RGB color to corresponding ASS color.
@@ -339,10 +328,10 @@ class Convert:
     @staticmethod
     def color_rgb_to_hsv(
         color_rgb: Union[
-            str, Tuple[Union[int, float], Union[int, float], Union[int, float]]
+            str, Tuple[float, float, float]
         ],
         round_output: bool = True,
-    ) -> Union[Tuple[int, int, int], Tuple[float, float, float]]:
+    ) -> Tuple[float, float, float]:
         """Converts from RGB color to corresponding HSV color.
 
         Parameters:
@@ -371,7 +360,7 @@ class Convert:
 
     @staticmethod
     def color_hsv_to_ass(
-        color_hsv: Tuple[Union[int, float], Union[int, float], Union[int, float]]
+        color_hsv: Tuple[float, float, float]
     ) -> str:
         """Converts from HSV color string to corresponding ASS color.
 
@@ -392,7 +381,7 @@ class Convert:
 
     @staticmethod
     def color_hsv_to_rgb(
-        color_hsv: Tuple[Union[int, float], Union[int, float], Union[int, float]],
+        color_hsv: Tuple[float, float, float],
         as_str: bool = False,
         round_output: bool = True,
     ) -> str:
@@ -428,7 +417,7 @@ class Convert:
 
     @staticmethod
     def text_to_shape(
-        obj: Union[Line, Word, Syllable, Char], fscx: float = None, fscy: float = None
+        fscx: Optional[float] = None, fscy: Optional[float] = None
     ) -> Shape:
         """Converts text with given style information to an ASS shape.
 
@@ -476,8 +465,8 @@ class Convert:
     def text_to_clip(
         obj: Union[Line, Word, Syllable, Char],
         an: int = 5,
-        fscx: float = None,
-        fscy: float = None,
+        fscx: Optional[float] = None,
+        fscy: Optional[float] = None,
     ) -> Shape:
         """Converts text with given style information to an ASS shape, applying some translation/scaling to it since
         it is not possible to position a shape with \\pos() once it is in a clip.
@@ -761,9 +750,9 @@ class Convert:
         return pixels
 
     @staticmethod
-    def image_to_ass(image):
-        pass
+    def image_to_ass(image: Any) -> NoReturn:
+        raise NotImplementedError
 
     @staticmethod
-    def image_to_pixels(image):
-        pass
+    def image_to_pixels(image: Any) -> NoReturn:
+        raise NotImplementedError

--- a/pyonfx/convert.py
+++ b/pyonfx/convert.py
@@ -75,6 +75,14 @@ class Convert:
 
     @staticmethod
     def timems_to_assts(ms: int) -> str:
+        """Converts milliseconds to ASS timestamp.
+
+        Parameters:
+            ms (int): Milliseconds.
+
+        Returns:
+            str: ASS timestamp
+        """
         if ms >= 0:
             assts = "{:d}:{:02d}:{:02d}.{:02d}".format(
                 math.floor(ms / 3600000) % 10,
@@ -88,6 +96,14 @@ class Convert:
 
     @staticmethod
     def assts_to_timems(assts: str) -> int:
+        """Converts ASS timestamp to milliseconds.
+
+        Parameters:
+            ms (str): ASS timestamp.
+
+        Returns:
+            int: Milliseconds
+        """
         if re.match(r"^\d:\d+:\d+\.\d+$", assts):
             ms = int(assts[0]) * 3600000 + int(assts[2:4]) * 60000 \
                 + int(assts[5:7]) * 1000 + int(assts[8:10]) * 10

--- a/pyonfx/convert.py
+++ b/pyonfx/convert.py
@@ -152,7 +152,7 @@ class Convert:
             ) from e
 
     @staticmethod
-    def alpha_dec_to_ass(alpha_dec: float) -> str:
+    def alpha_dec_to_ass(alpha_dec: Union[int, float]) -> str:
         """Converts from decimal value to corresponding ASS alpha string.
 
         Parameters:
@@ -186,8 +186,17 @@ class Convert:
         c: Union[
             str,
             Union[
-                Tuple[float, float, float],
-                Tuple[float, float, float, float],
+                Tuple[
+                    Union[int, float],
+                    Union[int, float],
+                    Union[int, float],
+                ],
+                Tuple[
+                    Union[int, float],
+                    Union[int, float],
+                    Union[int, float],
+                    Union[int, float],
+                ],
             ],
         ],
         input_format: ColorModel,
@@ -195,6 +204,8 @@ class Convert:
         round_output: bool = True,
     ) -> Union[
         str,
+        Tuple[int, int, int],
+        Tuple[int, int, int, int],
         Tuple[float, float, float],
         Tuple[float, float, float, float],
     ]:
@@ -340,7 +351,7 @@ class Convert:
     @staticmethod
     def color_rgb_to_ass(
         color_rgb: Union[
-            str, Tuple[float, float, float]
+            str, Tuple[Union[int, float], Union[int, float], Union[int, float]]
         ]
     ) -> str:
         """Converts from RGB color to corresponding ASS color.
@@ -367,10 +378,10 @@ class Convert:
     @staticmethod
     def color_rgb_to_hsv(
         color_rgb: Union[
-            str, Tuple[float, float, float]
+            str, Tuple[Union[int, float], Union[int, float], Union[int, float]]
         ],
         round_output: bool = True,
-    ) -> Tuple[float, float, float]:
+    ) -> Union[Tuple[int, int, int], Tuple[float, float, float]]:
         """Converts from RGB color to corresponding HSV color.
 
         Parameters:
@@ -399,7 +410,7 @@ class Convert:
 
     @staticmethod
     def color_hsv_to_ass(
-        color_hsv: Tuple[float, float, float]
+        color_hsv: Tuple[Union[int, float], Union[int, float], Union[int, float]]
     ) -> str:
         """Converts from HSV color string to corresponding ASS color.
 
@@ -420,7 +431,7 @@ class Convert:
 
     @staticmethod
     def color_hsv_to_rgb(
-        color_hsv: Tuple[float, float, float],
+        color_hsv: Tuple[Union[int, float], Union[int, float], Union[int, float]],
         as_str: bool = False,
         round_output: bool = True,
     ) -> str:

--- a/pyonfx/convert.py
+++ b/pyonfx/convert.py
@@ -109,10 +109,10 @@ class Convert:
         """Converts ASS timestamp to milliseconds.
 
         Parameters:
-            ms (str): ASS timestamp.
+            assts (str): ASS timestamp.
 
         Returns:
-            int: Milliseconds
+            int: Milliseconds.
         """
         if re.match(r"^\d:\d+:\d+\.\d+$", assts):
             ms = int(assts[0]) * 3600000 + int(assts[2:4]) * 60000 \

--- a/pyonfx/convert.py
+++ b/pyonfx/convert.py
@@ -20,7 +20,16 @@ import re
 import math
 import colorsys
 from enum import Enum
-from typing import Any, List, NamedTuple, NoReturn, Optional, Tuple, Union, TYPE_CHECKING
+from typing import (
+    Any,
+    List,
+    NamedTuple,
+    NoReturn,
+    Optional,
+    Tuple,
+    Union,
+    TYPE_CHECKING,
+)
 
 from .font_utility import Font
 
@@ -31,6 +40,7 @@ if TYPE_CHECKING:
 
 class Pixel(NamedTuple):
     """A simple NamedTuple to represent pixels"""
+
     x: float
     y: float
     alpha: int
@@ -101,7 +111,7 @@ class Convert:
                 math.floor(ms % 1000 / 10),
             )
         else:
-            raise ValueError('milliseconds must be >= 0')
+            raise ValueError("milliseconds must be >= 0")
         return assts
 
     @staticmethod
@@ -115,12 +125,15 @@ class Convert:
             int: Milliseconds.
         """
         if re.match(r"^\d:\d+:\d+\.\d+$", assts):
-            ms = int(assts[0]) * 3600000 + int(assts[2:4]) * 60000 \
-                + int(assts[5:7]) * 1000 + int(assts[8:10]) * 10
+            ms = (
+                int(assts[0]) * 3600000
+                + int(assts[2:4]) * 60000
+                + int(assts[5:7]) * 1000
+                + int(assts[8:10]) * 10
+            )
         else:
-            raise ValueError('ASS timestamp expected')
+            raise ValueError("ASS timestamp expected")
         return ms
-
 
     @staticmethod
     def alpha_ass_to_dec(alpha_ass: str) -> int:
@@ -468,7 +481,8 @@ class Convert:
     @staticmethod
     def text_to_shape(
         obj: Union[Line, Word, Syllable, Char],
-        fscx: Optional[float] = None, fscy: Optional[float] = None
+        fscx: Optional[float] = None,
+        fscy: Optional[float] = None,
     ) -> Shape:
         """Converts text with given style information to an ASS shape.
 

--- a/pyonfx/convert.py
+++ b/pyonfx/convert.py
@@ -335,7 +335,7 @@ class Convert:
             >>> (30, 28, 94)
             >>> (30.000000000000014, 28.451882845188294, 93.72549019607843)
         """
-        return cls.color(color_ass, ColorModel.ASS, ColorModel.HSV, round_output)
+        return Convert.color(color_ass, ColorModel.ASS, ColorModel.HSV, round_output)
 
     @staticmethod
     def color_rgb_to_ass(

--- a/pyonfx/convert.py
+++ b/pyonfx/convert.py
@@ -52,8 +52,8 @@ class Convert:
     the user to convert everything needed to the ASS format.
     """
 
-    @classmethod
-    def time(cls, ass_ms: Union[int, str]) -> Union[str, int]:
+    @staticmethod
+    def time(ass_ms: Union[int, str]) -> Union[str, int]:
         """Converts between milliseconds and ASS timestamp.
 
         You can probably ignore that function, you will not make use of it for KFX or typesetting generation.
@@ -66,10 +66,10 @@ class Convert:
         """
         # Milliseconds?
         if isinstance(ass_ms, int) and ass_ms >= 0:
-            return cls.timems_to_assts(ass_ms)
+            return Convert.timems_to_assts(ass_ms)
         # ASS timestamp?
         elif isinstance(ass_ms, str) and re.match(r"^\d:\d+:\d+\.\d+$", ass_ms):
-            return cls.assts_to_timems(ass_ms)
+            return Convert.assts_to_timems(ass_ms)
         else:
             raise ValueError("Milliseconds or ASS timestamp expected")
 
@@ -275,9 +275,8 @@ class Convert:
         except NameError as e:
             raise ValueError(f"Unsupported input_format ('{input_format}').") from e
 
-    @classmethod
+    @staticmethod
     def color_ass_to_rgb(
-        cls,
         color_ass: str, as_str: bool = False
     ) -> Union[str, Tuple[int, int, int]]:
         """Converts from ASS color string to corresponding RGB color.
@@ -299,13 +298,12 @@ class Convert:
             >>> (239, 205, 171)
             >>> "#EFCDAB"
         """
-        return cls.color(
+        return Convert.color(
             color_ass, ColorModel.ASS, ColorModel.RGB_STR if as_str else ColorModel.RGB
         )
 
-    @classmethod
+    @staticmethod
     def color_ass_to_hsv(
-        cls,
         color_ass: str, round_output: bool = True
     ) -> Union[Tuple[int, int, int], Tuple[float, float, float]]:
         """Converts from ASS color string to corresponding HSV color.
@@ -329,9 +327,8 @@ class Convert:
         """
         return cls.color(color_ass, ColorModel.ASS, ColorModel.HSV, round_output)
 
-    @classmethod
+    @staticmethod
     def color_rgb_to_ass(
-        cls,
         color_rgb: Union[
             str, Tuple[float, float, float]
         ]
@@ -351,15 +348,14 @@ class Convert:
 
             >>> "&HEFCDAB&"
         """
-        return cls.color(
+        return Convert.color(
             color_rgb,
             ColorModel.RGB_STR if type(color_rgb) is str else ColorModel.RGB,
             ColorModel.ASS,
         )
 
-    @classmethod
+    @staticmethod
     def color_rgb_to_hsv(
-        cls,
         color_rgb: Union[
             str, Tuple[float, float, float]
         ],
@@ -384,16 +380,15 @@ class Convert:
             >>> (210, 28, 94)
             >>> (210.0, 28.451882845188294, 93.72549019607843)
         """
-        return cls.color(
+        return Convert.color(
             color_rgb,
             ColorModel.RGB_STR if type(color_rgb) is str else ColorModel.RGB,
             ColorModel.HSV,
             round_output,
         )
 
-    @classmethod
+    @staticmethod
     def color_hsv_to_ass(
-        cls,
         color_hsv: Tuple[float, float, float]
     ) -> str:
         """Converts from HSV color string to corresponding ASS color.
@@ -411,11 +406,10 @@ class Convert:
 
             >>> "&H00FF55&"
         """
-        return cls.color(color_hsv, ColorModel.HSV, ColorModel.ASS)
+        return Convert.color(color_hsv, ColorModel.HSV, ColorModel.ASS)
 
-    @classmethod
+    @staticmethod
     def color_hsv_to_rgb(
-        cls,
         color_hsv: Tuple[float, float, float],
         as_str: bool = False,
         round_output: bool = True,
@@ -443,7 +437,7 @@ class Convert:
             >>> "#55FF00"
             >>> (84.99999999999999, 255.0, 0.0)
         """
-        return cls.color(
+        return Convert.color(
             color_hsv,
             ColorModel.HSV,
             ColorModel.RGB_STR if as_str else ColorModel.RGB,

--- a/pyonfx/font_utility.py
+++ b/pyonfx/font_utility.py
@@ -93,7 +93,7 @@ class Font:
             win32gui.SelectObject(self.dc, self.pycfont.GetSafeHandle())
             # Calculate metrics
             self.metrics = win32gui.GetTextMetrics(self.dc)
-        elif sys.platform == "linux" or sys.platform == "darwin":
+        elif sys.platform in {"linux", "darwin"}:
             surface = cairo.ImageSurface(cairo.Format.A8, 1, 1)
 
             self.context = cairo.Context(surface)
@@ -140,7 +140,7 @@ class Font:
                 self.metrics["InternalLeading"] * const,
                 self.metrics["ExternalLeading"] * const,
             )
-        elif sys.platform == "linux" or sys.platform == "darwin":
+        elif sys.platform in {"linux", "darwin"}:
             const = self.downscale * self.yscale * self.fonthack_scale / PANGO_SCALE
             return (
                 # 'height': (self.metrics.get_ascent() + self.metrics.get_descent()) * const,
@@ -160,7 +160,7 @@ class Font:
                 (cx * self.downscale + self.hspace * (len(text) - 1)) * self.xscale,
                 cy * self.downscale * self.yscale,
             )
-        elif sys.platform == "linux" or sys.platform == "darwin":
+        elif sys.platform in {"linux", "darwin"}:
             if not text:
                 return 0.0, 0.0
 
@@ -271,7 +271,7 @@ class Font:
             win32gui.AbortPath(self.dc)
 
             return Shape(" ".join(shape))
-        elif sys.platform == "linux" or sys.platform == "darwin":
+        elif sys.platform in {"linux", "darwin"}:
             # Defining variables
             shape, last_type = [], None
 

--- a/pyonfx/font_utility.py
+++ b/pyonfx/font_utility.py
@@ -28,7 +28,7 @@ if sys.platform == "win32":
     import win32gui  # pylint: disable=import-error
     import win32ui  # pylint: disable=import-error
     import win32con  # pylint: disable=import-error
-elif sys.platform in ["linux", "darwin"] and not "sphinx" in sys.modules:
+elif sys.platform in ["linux", "darwin"] and "sphinx" not in sys.modules:
     import cairo  # pylint: disable=import-error
     import gi  # pylint: disable=import-error
 

--- a/pyonfx/shape.py
+++ b/pyonfx/shape.py
@@ -912,8 +912,8 @@ class Shape:
         # Return result centered
         return shape.move()
 
-    @staticmethod
-    def star(edges: int, inner_size: float, outer_size: float) -> Shape:
+    @classmethod
+    def star(cls, edges: int, inner_size: float, outer_size: float) -> Shape:
         """Returns a shape object of a star object with given number of outer edges and sizes, centered around (0,0).
 
         **Tips:** *Different numbers of edges and edge distances allow individual n-angles.*
@@ -926,10 +926,10 @@ class Shape:
         Returns:
             A shape object as a string representing a star.
         """
-        return Shape.__glance_or_star(edges, inner_size, outer_size, "l")
+        return cls.__glance_or_star(edges, inner_size, outer_size, "l")
 
-    @staticmethod
-    def glance(edges: int, inner_size: float, outer_size: float) -> Shape:
+    @classmethod
+    def glance(cls, edges: int, inner_size: float, outer_size: float) -> Shape:
         """Returns a shape object of a glance object with given number of outer edges and sizes, centered around (0,0).
 
         **Tips:** *Glance is similar to Star, but with curves instead of inner edges between the outer edges.*
@@ -942,10 +942,10 @@ class Shape:
         Returns:
             A shape object as a string representing a glance.
         """
-        return Shape.__glance_or_star(edges, inner_size, outer_size, "b")
+        return cls.__glance_or_star(edges, inner_size, outer_size, "b")
 
-    @staticmethod
-    def rectangle(w: float = 1.0, h: float = 1.0) -> Shape:
+    @classmethod
+    def rectangle(cls, w: float = 1.0, h: float = 1.0) -> Shape:
         """Returns a shape object of a rectangle with given width and height, centered around (0,0).
 
         **Tips:** *A rectangle with width=1 and height=1 is a pixel.*
@@ -958,13 +958,13 @@ class Shape:
             A shape object representing an rectangle.
         """
         try:
-            f = Shape.format_value
+            f = cls.format_value
             return Shape("m 0 0 l %s 0 %s %s 0 %s 0 0" % (f(w), f(w), f(h), f(h)))
         except TypeError:
             raise TypeError("Number(s) expected")
 
-    @staticmethod
-    def triangle(size: float) -> Shape:
+    @classmethod
+    def triangle(cls, size: float) -> Shape:
         """Returns a shape object of an equilateral triangle with given side length, centered around (0,0).
 
         Parameters:
@@ -979,7 +979,7 @@ class Shape:
         except TypeError:
             raise TypeError("Number expected")
 
-        f = Shape.format_value
+        f = cls.format_value
         return Shape(
             "m %s %s l %s %s 0 %s %s %s"
             % (

--- a/pyonfx/shape.py
+++ b/pyonfx/shape.py
@@ -301,7 +301,7 @@ class Shape:
             y = 0
 
         # Update shape
-        self.map(lambda cx, cy, _: (cx + x, cy + y))
+        self.map(lambda cx, cy: (cx + x, cy + y))
         return self
 
     def flatten(self, tolerance: float = 1.0) -> Shape:
@@ -853,7 +853,7 @@ class Shape:
         # Build shape from template
         shape = Shape(
             "m 15 30 b 27 22 30 18 30 14 30 8 22 0 15 10 8 0 0 8 0 14 0 18 3 22 15 30"
-        ).map(lambda x, y, _: (x * mult, y * mult))
+        ).map(lambda x, y: (x * mult, y * mult))
 
         # Shift mid point of heart vertically
         count = 0

--- a/pyonfx/shape.py
+++ b/pyonfx/shape.py
@@ -297,7 +297,7 @@ class Shape:
             y = 0
 
         # Update shape
-        self.map(lambda cx, cy, typ: (cx + x, cy + y))
+        self.map(lambda cx, cy, _: (cx + x, cy + y))
         return self
 
     def flatten(self, tolerance: float = 1.0) -> Shape:

--- a/pyonfx/shape.py
+++ b/pyonfx/shape.py
@@ -854,7 +854,7 @@ class Shape:
         # Shift mid point of heart vertically
         count = 0
 
-        def shift_mid_point(x: float, y: float, _: Any) -> Tuple[float, float]:
+        def shift_mid_point(x, y, _):
             nonlocal count
             count += 1
 

--- a/pyonfx/shape.py
+++ b/pyonfx/shape.py
@@ -252,13 +252,13 @@ class Shape:
         """
 
         # Bounding data
-        x0: float = None
-        y0: float = None
-        x1: float = None
-        y1: float = None
+        x0: Optional[float] = None
+        y0: Optional[float] = None
+        x1: Optional[float] = None
+        y1: Optional[float] = None
 
         # Calculate minimal and maximal coordinates
-        def compute_edges(x, y):
+        def compute_edges(x, y, _):
             nonlocal x0, y0, x1, y1
             if x0 is not None:
                 x0, y0, x1, y1 = min(x0, x), min(y0, y), max(x1, x), max(y1, y)

--- a/pyonfx/shape.py
+++ b/pyonfx/shape.py
@@ -252,13 +252,13 @@ class Shape:
         """
 
         # Bounding data
-        x0: Optional[float] = None
-        y0: Optional[float] = None
-        x1: Optional[float] = None
-        y1: Optional[float] = None
+        x0: float = None
+        y0: float = None
+        x1: float = None
+        y1: float = None
 
         # Calculate minimal and maximal coordinates
-        def compute_edges(x, y, _):
+        def compute_edges(x, y):
             nonlocal x0, y0, x1, y1
             if x0 is not None:
                 x0, y0, x1, y1 = min(x0, x), min(y0, y), max(x1, x), max(y1, y)

--- a/pyonfx/shape.py
+++ b/pyonfx/shape.py
@@ -184,7 +184,7 @@ class Shape:
             while i < n:
                 try:
                     # Applying transformation
-                    x, y = fun(float(cmds_and_points[i]), float(cmds_and_points[i + 1]))
+                    x, y = fun(float(cmds_and_points[i]), float(cmds_and_points[i + 1]), None)
                 except TypeError:
                     # Values weren't returned, so we don't need to modify them
                     i += 2
@@ -296,7 +296,7 @@ class Shape:
             y = 0
 
         # Update shape
-        self.map(lambda cx, cy: (cx + x, cy + y))
+        self.map(lambda cx, cy, typ: (cx + x, cy + y))
         return self
 
     def flatten(self, tolerance: float = 1.0) -> Shape:
@@ -845,12 +845,12 @@ class Shape:
         # Build shape from template
         shape = Shape(
             "m 15 30 b 27 22 30 18 30 14 30 8 22 0 15 10 8 0 0 8 0 14 0 18 3 22 15 30"
-        ).map(lambda x, y: (x * mult, y * mult))
+        ).map(lambda x, y, typ: (x * mult, y * mult))
 
         # Shift mid point of heart vertically
         count = 0
 
-        def shift_mid_point(x, y):
+        def shift_mid_point(x: float, y: float, _: Any) -> Tuple[float, float]:
             nonlocal count
             count += 1
 

--- a/pyonfx/shape.py
+++ b/pyonfx/shape.py
@@ -17,7 +17,7 @@
 
 from __future__ import annotations
 import math
-from typing import Callable, Optional, List, Tuple, Union
+from typing import Any, Callable, Optional, Tuple, Union
 from pyquaternion import Quaternion
 from inspect import signature
 
@@ -39,7 +39,7 @@ class Shape:
             )
         self.drawing_cmds = drawing_cmds
 
-    def __repr__(self):
+    def __str__(self):
         # We return drawing commands as a string rapresentation of the object
         return self.drawing_cmds
 

--- a/pyonfx/shape.py
+++ b/pyonfx/shape.py
@@ -920,8 +920,8 @@ class Shape:
         # Return result centered
         return shape.move()
 
-    @classmethod
-    def star(cls, edges: int, inner_size: float, outer_size: float) -> Shape:
+    @staticmethod
+    def star(edges: int, inner_size: float, outer_size: float) -> Shape:
         """Returns a shape object of a star object with given number of outer edges and sizes, centered around (0,0).
 
         **Tips:** *Different numbers of edges and edge distances allow individual n-angles.*
@@ -934,10 +934,10 @@ class Shape:
         Returns:
             A shape object as a string representing a star.
         """
-        return cls.__glance_or_star(edges, inner_size, outer_size, "l")
+        return Shape.__glance_or_star(edges, inner_size, outer_size, "l")
 
-    @classmethod
-    def glance(cls, edges: int, inner_size: float, outer_size: float) -> Shape:
+    @staticmethod
+    def glance(edges: int, inner_size: float, outer_size: float) -> Shape:
         """Returns a shape object of a glance object with given number of outer edges and sizes, centered around (0,0).
 
         **Tips:** *Glance is similar to Star, but with curves instead of inner edges between the outer edges.*
@@ -950,10 +950,10 @@ class Shape:
         Returns:
             A shape object as a string representing a glance.
         """
-        return cls.__glance_or_star(edges, inner_size, outer_size, "b")
+        return Shape.__glance_or_star(edges, inner_size, outer_size, "b")
 
-    @classmethod
-    def rectangle(cls, w: float = 1.0, h: float = 1.0) -> Shape:
+    @staticmethod
+    def rectangle(w: float = 1.0, h: float = 1.0) -> Shape:
         """Returns a shape object of a rectangle with given width and height, centered around (0,0).
 
         **Tips:** *A rectangle with width=1 and height=1 is a pixel.*
@@ -966,13 +966,13 @@ class Shape:
             A shape object representing an rectangle.
         """
         try:
-            f = cls.format_value
+            f = Shape.format_value
             return Shape("m 0 0 l %s 0 %s %s 0 %s 0 0" % (f(w), f(w), f(h), f(h)))
         except TypeError:
             raise TypeError("Number(s) expected")
 
-    @classmethod
-    def triangle(cls, size: float) -> Shape:
+    @staticmethod
+    def triangle(size: float) -> Shape:
         """Returns a shape object of an equilateral triangle with given side length, centered around (0,0).
 
         Parameters:
@@ -987,7 +987,7 @@ class Shape:
         except TypeError:
             raise TypeError("Number expected")
 
-        f = cls.format_value
+        f = Shape.format_value
         return Shape(
             "m %s %s l %s %s 0 %s %s %s"
             % (

--- a/pyonfx/shape.py
+++ b/pyonfx/shape.py
@@ -158,7 +158,8 @@ class Shape:
         **Tips:** *Working with outline points can be used to deform the whole shape and make f.e. a wobble effect.*
 
         Parameters:
-            fun (function): A function with two (or optionally three) parameters. It will define how each coordinate will be changed. The first two parameters represent the x and y coordinates of each point. The third optional it represents the type of each point (move, line, bezier...).
+            fun (function): A function with two (or optionally three) parameters. It will define how each coordinate will be changed.
+            The first two parameters represent the x and y coordinates of each point. The third optional one represents the type of each point (move, line, bezier...).
 
         Returns:
             A pointer to the current object.
@@ -525,8 +526,12 @@ class Shape:
         **Tips:** *You can call this before using :func:`map` to work with more outline points for smoother deforming.*
 
         Parameters:
-            max_len (int or float): The max length that you want all the lines to be
-            tolerance (float): Angle in degree to define a bezier curve as flat (increasing it will boost performance during reproduction, but lower accuracy)
+            max_len (int or float):
+                The max length that you want all the lines to be
+
+            tolerance (float):
+                Angle in degree to define a bezier curve as flat. Currently not implemented.
+                (increasing it will boost performance during reproduction, but lower accuracy)
 
         Returns:
             A pointer to the current object.

--- a/pyonfx/shape.py
+++ b/pyonfx/shape.py
@@ -530,8 +530,7 @@ class Shape:
                 The max length that you want all the lines to be
 
             tolerance (float):
-                Angle in degree to define a bezier curve as flat. Currently not implemented.
-                (increasing it will boost performance during reproduction, but lower accuracy)
+                Angle in degree to define a bezier curve as flat. (Increasing it will boost performance during reproduction, but lower accuracy)
 
         Returns:
             A pointer to the current object.
@@ -576,7 +575,7 @@ class Shape:
                 return f"{x1} {y1}", [x1, y1]
 
         # Getting all points and commands in a list
-        cmds_and_points = self.flatten().drawing_cmds.split()
+        cmds_and_points = self.flatten(tolerance).drawing_cmds.split()
         i = 0
         n = len(cmds_and_points)
 

--- a/pyonfx/shape.py
+++ b/pyonfx/shape.py
@@ -252,10 +252,10 @@ class Shape:
         """
 
         # Bounding data
-        x0: float = None
-        y0: float = None
-        x1: float = None
-        y1: float = None
+        x0 = None
+        y0 = None
+        x1 = None
+        y1 = None
 
         # Calculate minimal and maximal coordinates
         def compute_edges(x, y):

--- a/pyonfx/shape.py
+++ b/pyonfx/shape.py
@@ -151,7 +151,7 @@ class Shape:
         return False
 
     def map(
-        self, fun: Callable[[float, float, Optional[str]], Tuple[float, float]]
+        self, fun: Union[Callable[[float, float], Tuple[float, float]], Callable[[float, float, str], Tuple[float, float]]]
     ) -> Shape:
         """Sends every point of a shape through given transformation function to change them.
 
@@ -185,7 +185,7 @@ class Shape:
             while i < n:
                 try:
                     # Applying transformation
-                    x, y = fun(float(cmds_and_points[i]), float(cmds_and_points[i + 1]), None)
+                    x, y = fun(float(cmds_and_points[i]), float(cmds_and_points[i + 1]))
                 except TypeError:
                     # Values weren't returned, so we don't need to modify them
                     i += 2

--- a/pyonfx/shape.py
+++ b/pyonfx/shape.py
@@ -849,7 +849,7 @@ class Shape:
         # Build shape from template
         shape = Shape(
             "m 15 30 b 27 22 30 18 30 14 30 8 22 0 15 10 8 0 0 8 0 14 0 18 3 22 15 30"
-        ).map(lambda x, y, typ: (x * mult, y * mult))
+        ).map(lambda x, y, _: (x * mult, y * mult))
 
         # Shift mid point of heart vertically
         count = 0

--- a/pyonfx/shape.py
+++ b/pyonfx/shape.py
@@ -151,7 +151,11 @@ class Shape:
         return False
 
     def map(
-        self, fun: Union[Callable[[float, float], Tuple[float, float]], Callable[[float, float, str], Tuple[float, float]]]
+        self,
+        fun: Union[
+            Callable[[float, float], Tuple[float, float]],
+            Callable[[float, float, str], Tuple[float, float]],
+        ],
     ) -> Shape:
         """Sends every point of a shape through given transformation function to change them.
 

--- a/pyonfx/utils.py
+++ b/pyonfx/utils.py
@@ -44,12 +44,7 @@ class Utils:
         Returns:
             A list containing lines_chars_syls_or_words without objects with duration equals to zero or blank text (no text or only spaces).
         """
-        out = []
-        for obj in lines_words_syls_or_chars:
-            if obj.text.strip() and obj.duration > 0:
-                out.append(obj)
-        return out
-        # return [obj for obj in lines_words_syls_or_chars if obj.text.strip() and obj.duration > 0]
+        return [obj for obj in lines_words_syls_or_chars if obj.text.strip() and obj.duration > 0]
 
     @staticmethod
     def clean_tags(text: str) -> str:

--- a/pyonfx/utils.py
+++ b/pyonfx/utils.py
@@ -16,14 +16,15 @@
 # along with this program. If not, see http://www.gnu.org/licenses/.
 
 from __future__ import annotations
+
 import math
 import re
-from typing import List, Union, TYPE_CHECKING
+from typing import List, TypeVar, Union
 
-from .convert import Convert, ColorModel
+from .ass_core import Char, Line, Syllable, Word
+from .convert import ColorModel, Convert
 
-if TYPE_CHECKING:
-    from .ass_core import Line, Word, Syllable, Char
+AssTextT = TypeVar('AssTextT', bound=Union[Line, Word, Syllable, Char])
 
 
 class Utils:
@@ -32,9 +33,7 @@ class Utils:
     """
 
     @staticmethod
-    def all_non_empty(
-        lines_words_syls_or_chars: Union[List[Line], List[Word], List[Syllable], List[Char]],
-    ) -> Union[List[Line], List[Word], List[Syllable], List[Char]]:
+    def all_non_empty(lines_words_syls_or_chars: List[AssTextT]) -> List[AssTextT]:
         """
         Helps to not check everytime for text containing only spaces or object's duration equals to zero.
 

--- a/pyonfx/utils.py
+++ b/pyonfx/utils.py
@@ -24,7 +24,7 @@ from typing import List, TypeVar, Union
 from .ass_core import Char, Line, Syllable, Word
 from .convert import ColorModel, Convert
 
-AssTextT = TypeVar('AssTextT', bound=Union[Line, Word, Syllable, Char])
+AssTextT = TypeVar("AssTextT", bound=Union[Line, Word, Syllable, Char])
 
 
 class Utils:
@@ -43,7 +43,11 @@ class Utils:
         Returns:
             A list containing lines_chars_syls_or_words without objects with duration equals to zero or blank text (no text or only spaces).
         """
-        return [obj for obj in lines_words_syls_or_chars if obj.text.strip() and obj.duration > 0]
+        return [
+            obj
+            for obj in lines_words_syls_or_chars
+            if obj.text.strip() and obj.duration > 0
+        ]
 
     @staticmethod
     def clean_tags(text: str) -> str:

--- a/pyonfx/utils.py
+++ b/pyonfx/utils.py
@@ -33,8 +33,8 @@ class Utils:
 
     @staticmethod
     def all_non_empty(
-        lines_chars_syls_or_words: List[Union[Line, Word, Syllable, Char]]
-    ) -> List[Union[Line, Word, Syllable, Char]]:
+        lines_words_syls_or_chars: Union[List[Line], List[Word], List[Syllable], List[Char]],
+    ) -> Union[List[Line], List[Word], List[Syllable], List[Char]]:
         """
         Helps to not check everytime for text containing only spaces or object's duration equals to zero.
 
@@ -45,10 +45,11 @@ class Utils:
             A list containing lines_chars_syls_or_words without objects with duration equals to zero or blank text (no text or only spaces).
         """
         out = []
-        for obj in lines_chars_syls_or_words:
+        for obj in lines_words_syls_or_chars:
             if obj.text.strip() and obj.duration > 0:
                 out.append(obj)
         return out
+        # return [obj for obj in lines_words_syls_or_chars if obj.text.strip() and obj.duration > 0]
 
     @staticmethod
     def clean_tags(text: str) -> str:

--- a/tests/test_shape.py
+++ b/tests/test_shape.py
@@ -6,19 +6,19 @@ def test_transform():
     # Without type checking
     original = Shape("m 0 0 l 20 0 20 10 0 10")
     dest = Shape("m 10 5 l 30 5 30 15 10 15")
-    assert original.map(lambda x, y: (x + 10, y + 5)) == dest
+    assert original.map(lambda x, y, _: (x + 10, y + 5)) == dest
 
     original = Shape("m -100.5 0 l 100 0 b 100 100 -100 100 -100.5 0 c")
     dest = Shape("m -10.05 0 l 10 0 b 10 200 -10 200 -10.05 0 c")
-    assert original.map(lambda x, y: (x / 10, y * 2)) == dest
+    assert original.map(lambda x, y, _: (x / 10, y * 2)) == dest
 
     original = Shape("m 0.5 0.4 l 20.5 0.6 20.7 10.1 0.6 10.4")
     dest = Shape("m 0 0 l 20 1 21 10 1 10")
-    assert original.map(lambda x, y: (round(x), round(y))) == dest
+    assert original.map(lambda x, y, _: (round(x), round(y))) == dest
 
     original = Shape("m 0 0 l 20 0 20 10 0 10 22")
     with pytest.raises(ValueError) as e_info:
-        original.map(lambda x, y: (x, y)) == dest
+        original.map(lambda x, y, _: (x, y)) == dest
 
     # With type checking
     original = Shape("m 0 0 l 20 0 20 10 0 10")

--- a/tests/test_shape.py
+++ b/tests/test_shape.py
@@ -6,19 +6,19 @@ def test_transform():
     # Without type checking
     original = Shape("m 0 0 l 20 0 20 10 0 10")
     dest = Shape("m 10 5 l 30 5 30 15 10 15")
-    assert original.map(lambda x, y, _: (x + 10, y + 5)) == dest
+    assert original.map(lambda x, y: (x + 10, y + 5)) == dest
 
     original = Shape("m -100.5 0 l 100 0 b 100 100 -100 100 -100.5 0 c")
     dest = Shape("m -10.05 0 l 10 0 b 10 200 -10 200 -10.05 0 c")
-    assert original.map(lambda x, y, _: (x / 10, y * 2)) == dest
+    assert original.map(lambda x, y: (x / 10, y * 2)) == dest
 
     original = Shape("m 0.5 0.4 l 20.5 0.6 20.7 10.1 0.6 10.4")
     dest = Shape("m 0 0 l 20 1 21 10 1 10")
-    assert original.map(lambda x, y, _: (round(x), round(y))) == dest
+    assert original.map(lambda x, y: (round(x), round(y))) == dest
 
     original = Shape("m 0 0 l 20 0 20 10 0 10 22")
     with pytest.raises(ValueError) as e_info:
-        original.map(lambda x, y, _: (x, y)) == dest
+        original.map(lambda x, y: (x, y)) == dest
 
     # With type checking
     original = Shape("m 0 0 l 20 0 20 10 0 10")


### PR DESCRIPTION
This PR is aiming to fix some typehint  and logic errors. There are still a lot of problems reported by mypy and pylance though.

TODO that would be nice:
* Make an abstract super class for Line, Word and Char since they share a lot of attributes.
* Use `isinstance` instead of `type`
* Dissociate multiple return types. It's annoying for the user to know what a type a function returns unless they run the script. But it goes against the purpose of typehinting -> knowing type and prevents errors before running a script.

I would like to know your opinion about this before continuying to make new commits.