### PR TITLE
New version of FrameUtility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,9 @@ jobs:
 
       - name: Install platform-specific requirements (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get install libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0 python3-gi python3-gi-cairo
+        run: |
+          sudo apt-get update
+          sudo apt-get install libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0 python3-gi python3-gi-cairo
       - name: Install platform-specific requirements (macOS) # Note: brew is very slow sometimes. TODO: speedup brew by using caching.
         if: matrix.os == 'macos-latest'
         run: brew install pygobject3 gtk+3 cairo py3cairo pkg-config

--- a/.gitignore
+++ b/.gitignore
@@ -128,9 +128,7 @@ docs/build/
 
 # Example & test outputs
 examples/Output.ass
-examples/1 - Basics/Output.ass
-examples/2 - Beginner/Output.ass
-examples/3 - Advanced/Output.ass
+examples/*/Output.ass
 tests/Output.ass
 
 # Misc

--- a/examples/2 - Beginner/2 - Utilities.py
+++ b/examples/2 - Beginner/2 - Utilities.py
@@ -42,14 +42,14 @@ def romaji(line, l):
         io.write_line(l)
 
         # Main Effect
-        # Let's create a FrameUtility object and set up an interval for the random positions
+        # Let's create a FrameUtility object and set up a radius for the random positions
         FU = FrameUtility(
             line.start_time + syl.start_time, line.start_time + syl.end_time
         )
-        interval = 2
+        radius = 2
 
         # Starting to iterate over the frames
-        for s, e, i, n in FU:
+        for s, e, _, _ in FU:
             l.layer = 1
 
             l.start_time = s
@@ -62,8 +62,8 @@ def romaji(line, l):
             fsc += FU.add(syl.duration / 3, syl.duration, -40)
 
             l.text = "{\\an5\\pos(%.3f,%.3f)\\fscx%.3f\\fscy%.3f}%s" % (
-                syl.center + random.uniform(-interval, interval),
-                syl.middle + random.uniform(-interval, interval),
+                syl.center + random.uniform(-radius, radius),
+                syl.middle + random.uniform(-radius, radius),
                 fsc,
                 fsc,
                 syl.text,

--- a/examples/2 - Beginner/3 - Variants.py
+++ b/examples/2 - Beginner/3 - Variants.py
@@ -45,15 +45,18 @@ def romaji(line, l):
         l.end_time = line.start_time + syl.start_time
         l.dur = l.end_time - l.start_time
 
-        l.text = "{\\an5\\move(%.3f,%.3f,%.3f,%.3f,0,%d)\\blur2\\t(0,%d,\\blur0)\\fad(%d,0)}%s" % (
-            syl.center + math.cos(syl.i / 2) * off_x,
-            syl.middle + math.sin(syl.i / 4) * off_y,
-            syl.center,
-            syl.middle,
-            delay,
-            delay,
-            delay,
-            syl.text,
+        l.text = (
+            "{\\an5\\move(%.3f,%.3f,%.3f,%.3f,0,%d)\\blur2\\t(0,%d,\\blur0)\\fad(%d,0)}%s"
+            % (
+                syl.center + math.cos(syl.i / 2) * off_x,
+                syl.middle + math.sin(syl.i / 4) * off_y,
+                syl.center,
+                syl.middle,
+                delay,
+                delay,
+                delay,
+                syl.text,
+            )
         )
 
         io.write_line(l)
@@ -83,16 +86,19 @@ def romaji(line, l):
                 l.dur,
             )
 
-        l.text = "{\\an5\\pos(%.3f,%.3f)%s\\t(0,80,\\fscx105\\fscy105\\1c%s\\3c%s)\\t(80,%d,\\fscx100\\fscy100\\1c%s\\3c%s)}%s" % (
-            syl.center,
-            syl.middle,
-            on_inline_effect_2,
-            c1,
-            c3,
-            l.dur - 80,
-            line.styleref.color1,
-            line.styleref.color3,
-            syl.text,
+        l.text = (
+            "{\\an5\\pos(%.3f,%.3f)%s\\t(0,80,\\fscx105\\fscy105\\1c%s\\3c%s)\\t(80,%d,\\fscx100\\fscy100\\1c%s\\3c%s)}%s"
+            % (
+                syl.center,
+                syl.middle,
+                on_inline_effect_2,
+                c1,
+                c3,
+                l.dur - 80,
+                line.styleref.color1,
+                line.styleref.color3,
+                syl.text,
+            )
         )
 
         io.write_line(l)
@@ -197,15 +203,18 @@ def kanji(line, l):
         l.end_time = line.start_time + syl.start_time
         l.dur = l.end_time - l.start_time
 
-        l.text = "{\\an5\\move(%.3f,%.3f,%.3f,%.3f,0,%d)\\blur2\\t(0,%d,\\blur0)\\fad(%d,0)}%s" % (
-            syl.center + math.cos(syl.i / 2) * off_x,
-            syl.middle + math.sin(syl.i / 4) * off_y,
-            syl.center,
-            syl.middle,
-            delay,
-            delay,
-            delay,
-            syl.text,
+        l.text = (
+            "{\\an5\\move(%.3f,%.3f,%.3f,%.3f,0,%d)\\blur2\\t(0,%d,\\blur0)\\fad(%d,0)}%s"
+            % (
+                syl.center + math.cos(syl.i / 2) * off_x,
+                syl.middle + math.sin(syl.i / 4) * off_y,
+                syl.center,
+                syl.middle,
+                delay,
+                delay,
+                delay,
+                syl.text,
+            )
         )
 
         io.write_line(l)
@@ -235,16 +244,19 @@ def kanji(line, l):
                 l.dur,
             )
 
-        l.text = "{\\an5\\pos(%.3f,%.3f)%s\\t(0,80,\\fscx105\\fscy105\\1c%s\\3c%s)\\t(80,%d,\\fscx100\\fscy100\\1c%s\\3c%s)}%s" % (
-            syl.center,
-            syl.middle,
-            on_inline_effect_2,
-            c1,
-            c3,
-            l.dur - 80,
-            line.styleref.color1,
-            line.styleref.color3,
-            syl.text,
+        l.text = (
+            "{\\an5\\pos(%.3f,%.3f)%s\\t(0,80,\\fscx105\\fscy105\\1c%s\\3c%s)\\t(80,%d,\\fscx100\\fscy100\\1c%s\\3c%s)}%s"
+            % (
+                syl.center,
+                syl.middle,
+                on_inline_effect_2,
+                c1,
+                c3,
+                l.dur - 80,
+                line.styleref.color1,
+                line.styleref.color3,
+                syl.text,
+            )
         )
 
         io.write_line(l)

--- a/examples/3 - Advanced/1 - WIP.py
+++ b/examples/3 - Advanced/1 - WIP.py
@@ -58,14 +58,17 @@ def romaji(line, l):
 
             io.write_line(l)
 
-            l.text = "{\\an5\\pos(%.3f,%.3f)\\fscx%.3f\\fscy%.3f\\1c&H0000FF&\\bord0\\shad0\\blur2\\alpha%s\\clip(%s)\\p1}%s" % (
-                syl.center + rand,
-                syl.middle + rand,
-                fsc,
-                fsc,
-                alpha,
-                Convert.text_to_clip(syl, an=9, fscx=fsc, fscy=fsc),
-                circle,
+            l.text = (
+                "{\\an5\\pos(%.3f,%.3f)\\fscx%.3f\\fscy%.3f\\1c&H0000FF&\\bord0\\shad0\\blur2\\alpha%s\\clip(%s)\\p1}%s"
+                % (
+                    syl.center + rand,
+                    syl.middle + rand,
+                    fsc,
+                    fsc,
+                    alpha,
+                    Convert.text_to_clip(syl, an=9, fscx=fsc, fscy=fsc),
+                    circle,
+                )
             )
 
             io.write_line(l)

--- a/pyonfx/__init__.py
+++ b/pyonfx/__init__.py
@@ -6,4 +6,4 @@ from .convert import Convert, ColorModel
 from .shape import Shape
 from .utils import Utils, FrameUtility, ColorUtility
 
-__version__ = "0.9.12"
+__version__ = "0.9.13"

--- a/pyonfx/convert.py
+++ b/pyonfx/convert.py
@@ -110,12 +110,12 @@ class Convert:
             The output represents ``frames`` converted.
         """
         # Logic taken from: https://github.com/Ristellise/AegisubDC/blob/d4e6c9afef17953c2d62b874665a1bfb62949b32/libaegisub/common/vfr.cpp#L234
-        curr_ms = math.floor(frames * 1000 / fps)
+        curr_ms = frames * 1000 / fps
         if is_start:
-            prev_ms = math.floor((frames - 1) * 1000 / fps)
+            prev_ms = (frames - 1) * 1000 / fps
             return math.floor(prev_ms + (curr_ms - prev_ms + 1) / 2)
         else:
-            next_ms = math.floor((frames + 1) * 1000 / fps)
+            next_ms = (frames + 1) * 1000 / fps
             return math.floor(curr_ms + (next_ms - curr_ms + 1) / 2)
 
     @staticmethod

--- a/pyonfx/convert.py
+++ b/pyonfx/convert.py
@@ -47,20 +47,20 @@ class ColorModel(Enum):
 
 class Convert:
 
-    """
-    Parameters:
-        ms (positive int): time
-        fps (positive Fraction): Frame by second
-        type (Need to be equal to "start" or "end")
-
-    Returns:
-        Return: This fonction will return the ms when the frame start or end (it depend of the type)
-                It is the equivalent to ctrl + 3 and ctrl + 4 aegisub shortcut
-    """
     @staticmethod
-    def bound2frame(ms: int, fps: Fraction, type: string) -> int:
+    def bound2frame(ms: int, fps: Fraction, timeType: str) -> int:
+        """
+        Parameters:
+            ms (positive int): time
+            fps (positive Fraction): Frame by second
+            timeType (Need to be equal to "start" or "end")
 
-        if (type == "start" or type == "end"):
+        Returns:
+            Return: This fonction will return the ms when the frame start or end (it depend of the type)
+                    It is the equivalent to ctrl + 3 and ctrl + 4 aegisub shortcut
+        """        
+
+        if timeType == "start" or timeType == "end":
             return Convert.frame2ms(Convert.ms2frame(ms, fps, type), fps, type)
 
         else:
@@ -68,13 +68,13 @@ class Convert:
 
 
     @staticmethod
-    def ms2frame(ms:int, fps: Fraction, type: string = "none") -> int:
+    def ms2frame(ms:int, fps: Fraction, timeType: str = "none") -> int:
 
         # Same logic that is there: https://github.com/Ristellise/AegisubDC/blob/d4e6c9afef17953c2d62b874665a1bfb62949b32/libaegisub/common/vfr.cpp#L219
-        if(type == "start"):
+        if timeType == "start":
             return Convert.ms2frame(ms - 1, fps) + 1
 
-        if(type == "end") :
+        if timeType == "end":
             return Convert.ms2frame(ms - 1, fps)
 
         # I don't know why, but if x = 1000.989, aegisub will considered it like 1002.This is the reason why we add 0.011
@@ -83,14 +83,15 @@ class Convert:
         return image - 1
 
     @staticmethod
-    def frame2ms(frame:int, fps: Fraction, type: string = "none") -> int:
+    def frame2ms(frame:int, fps: Fraction, timeType: str = "none") -> int:
 
         # Same logic that is there: https://github.com/Ristellise/AegisubDC/blob/d4e6c9afef17953c2d62b874665a1bfb62949b32/libaegisub/common/vfr.cpp#L234
-        if(type == "start"):
+        if timeType == "start":
             prev = Convert.frame2ms(frame - 1, fps)
             cur = Convert.frame2ms(frame, fps)
             return math.floor(prev + (cur - prev + 1) / 2)
-        if(type == "end") :
+
+        if timeType == "end":
             cur = Convert.frame2ms(frame, fps)
             next = Convert.frame2ms(frame + 1, fps)
             return math.floor(cur + (next - cur + 1) / 2)

--- a/pyonfx/convert.py
+++ b/pyonfx/convert.py
@@ -93,13 +93,12 @@ class Convert:
         Returns:
             The output represents ``ms`` converted.
         """
-        # Logic taken from: https://github.com/Ristellise/AegisubDC/blob/d4e6c9afef17953c2d62b874665a1bfb62949b32/libaegisub/common/vfr.cpp#L219
+        # Logic taken from: https://github.com/Aegisub/Aegisub/blob/master/libaegisub/common/vfr.cpp#L205
         if ms < 0:
             raise ValueError("Parameter 'ms' must be an integer >= 0.")
         if fps <= 0:
             raise ValueError("Parameter 'fps' must be an integer > 0.")
-        if ms == 0:
-            return 0
+        # NOTE: a frame can be negative in Aegisub, so here we allow this possibility
         return math.ceil((ms - 0.5) / 1000 * fps) - (0 if is_start else 1)
 
     @staticmethod
@@ -116,12 +115,13 @@ class Convert:
         Returns:
             The output represents ``frames`` converted.
         """
-        # Logic taken from: https://github.com/Ristellise/AegisubDC/blob/d4e6c9afef17953c2d62b874665a1bfb62949b32/libaegisub/common/vfr.cpp#L234
+        # Logic taken from: https://github.com/Aegisub/Aegisub/blob/master/libaegisub/common/vfr.cpp#L233
         if frames < 0:
             raise ValueError("Parameter 'frames' must be an integer >= 0.")
         if fps <= 0:
             raise ValueError("Parameter 'fps' must be an integer > 0.")
-        if frames == 0:
+        # Since ms can't be negative, we have to handle frame 0 when converting frame value for a start time
+        if is_start and frames == 0:
             return 0
         curr_ms = frames * 1000 / fps
         if is_start:
@@ -137,7 +137,7 @@ class Convert:
     ) -> int:
         """
         Moves the ms to when the corresponding frame starts or ends (depending on ``is_start``).
-        It is something close to "CTRL + 3" and "CTRL + 4" Aegisub's shortcuts.
+        It is something close to using "CTRL + 3" and "CTRL + 4" on Aegisub 3.2.2.
 
         Parameters:
             ms (int): Milliseconds.
@@ -147,6 +147,9 @@ class Convert:
         Returns:
             The output represents ``ms`` converted.
         """
+        # Since ms can't be negative, we have to handle frame 0 when converting frame value for a start time
+        if ms == 0:
+            return 0
         return Convert.frames_to_ms(
             Convert.ms_to_frames(ms, fps, is_start), fps, is_start
         )

--- a/pyonfx/convert.py
+++ b/pyonfx/convert.py
@@ -103,7 +103,9 @@ class Convert:
         return math.ceil((ms - 0.5) / 1000 * fps) - (0 if is_start else 1)
 
     @staticmethod
-    def frames_to_ms(frames: int, fps: Union[int, float, Fraction], is_start: bool) -> int:
+    def frames_to_ms(
+        frames: int, fps: Union[int, float, Fraction], is_start: bool
+    ) -> int:
         """Converts from frames to milliseconds.
 
         Parameters:
@@ -130,7 +132,9 @@ class Convert:
             return math.floor(curr_ms + (next_ms - curr_ms + 1) / 2)
 
     @staticmethod
-    def move_ms_to_frame(ms: int, fps: Union[int, float, Fraction], is_start: bool) -> int:
+    def move_ms_to_frame(
+        ms: int, fps: Union[int, float, Fraction], is_start: bool
+    ) -> int:
         """
         Moves the ms to when the corresponding frame starts or ends (depending on ``is_start``).
         It is something close to "CTRL + 3" and "CTRL + 4" Aegisub's shortcuts.
@@ -811,7 +815,7 @@ class Convert:
                         Pixel(
                             x=(x - shift_x) * downscale,
                             y=(y - shift_y) * downscale,
-                            alpha=255 - round(opacity * downscale ** 2),
+                            alpha=255 - round(opacity * downscale**2),
                         )
                     )
 

--- a/pyonfx/convert.py
+++ b/pyonfx/convert.py
@@ -82,34 +82,45 @@ class Convert:
             raise ValueError("Milliseconds or ASS timestamp expected")
 
     @staticmethod
-    def ms_to_frames(ms: int, fps: Fraction, is_start: bool) -> int:
+    def ms_to_frames(ms: int, fps: Union[int, float, Fraction], is_start: bool) -> int:
         """Converts from milliseconds to frames.
 
         Parameters:
             ms (int): Milliseconds.
-            fps (Fraction): Frames per second.
+            fps (positive int, float or Fraction): Frames per second.
             is_start (bool): True if this time will be used for the start_time of a line, else False.
 
         Returns:
             The output represents ``ms`` converted.
         """
         # Logic taken from: https://github.com/Ristellise/AegisubDC/blob/d4e6c9afef17953c2d62b874665a1bfb62949b32/libaegisub/common/vfr.cpp#L219
-        # TODO: we still need to investigate on the correctness of this formula
+        if ms < 0:
+            raise ValueError("Parameter 'ms' must be an integer >= 0.")
+        if fps <= 0:
+            raise ValueError("Parameter 'fps' must be an integer > 0.")
+        if ms == 0:
+            return 0
         return math.ceil((ms - 0.5) / 1000 * fps) - (0 if is_start else 1)
 
     @staticmethod
-    def frames_to_ms(frames: int, fps: Fraction, is_start: bool) -> int:
+    def frames_to_ms(frames: int, fps: Union[int, float, Fraction], is_start: bool) -> int:
         """Converts from frames to milliseconds.
 
         Parameters:
             frames (int): Frames.
-            fps (Fraction): Frames per second.
+            fps (positive int, float or Fraction): Frames per second.
             is_start (bool): True if this time will be used for the start_time of a line, else False.
 
         Returns:
             The output represents ``frames`` converted.
         """
         # Logic taken from: https://github.com/Ristellise/AegisubDC/blob/d4e6c9afef17953c2d62b874665a1bfb62949b32/libaegisub/common/vfr.cpp#L234
+        if frames < 0:
+            raise ValueError("Parameter 'frames' must be an integer >= 0.")
+        if fps <= 0:
+            raise ValueError("Parameter 'fps' must be an integer > 0.")
+        if frames == 0:
+            return 0
         curr_ms = frames * 1000 / fps
         if is_start:
             prev_ms = (frames - 1) * 1000 / fps
@@ -119,14 +130,14 @@ class Convert:
             return math.floor(curr_ms + (next_ms - curr_ms + 1) / 2)
 
     @staticmethod
-    def move_ms_to_frame(ms: int, fps: Fraction, is_start: bool) -> int:
+    def move_ms_to_frame(ms: int, fps: Union[int, float, Fraction], is_start: bool) -> int:
         """
         Moves the ms to when the corresponding frame starts or ends (depending on ``is_start``).
         It is something close to "CTRL + 3" and "CTRL + 4" Aegisub's shortcuts.
 
         Parameters:
             ms (int): Milliseconds.
-            fps (Fraction): Frames per second.
+            fps (positive int, float or Fraction): Frames per second.
             is_start (bool): True if this time will be used for the start_time of a line, else False.
 
         Returns:

--- a/pyonfx/convert.py
+++ b/pyonfx/convert.py
@@ -61,10 +61,10 @@ class Convert:
         """        
 
         if timeType == "start" or timeType == "end":
-            return Convert.frame2ms(Convert.ms2frame(ms, fps, type), fps, type)
+            return Convert.frame2ms(Convert.ms2frame(ms, fps, timeType), fps, timeType)
 
         else:
-            raise TypeError("Expected type to be \"start\" or \"end\", got %s." % type)
+            raise TypeError("Expected type to be \"start\" or \"end\", got %s." % timeType)
 
 
     @staticmethod

--- a/pyonfx/convert.py
+++ b/pyonfx/convert.py
@@ -88,7 +88,7 @@ class Convert:
         Parameters:
             ms (int): Milliseconds.
             fps (Fraction): Frames per second.
-            is_start (bool): True if this time will be used for a start_time of a line, else False.
+            is_start (bool): True if this time will be used for the start_time of a line, else False.
 
         Returns:
             The output represents ``ms`` converted.
@@ -104,7 +104,7 @@ class Convert:
         Parameters:
             frames (int): Frames.
             fps (Fraction): Frames per second.
-            is_start (bool): True if this time will be used for a start_time of a line, else False.
+            is_start (bool): True if this time will be used for the start_time of a line, else False.
 
         Returns:
             The output represents ``frames`` converted.
@@ -127,7 +127,7 @@ class Convert:
         Parameters:
             ms (int): Milliseconds.
             fps (Fraction): Frames per second.
-            is_start (bool): True if this time will be used for a start_time of a line, else False.
+            is_start (bool): True if this time will be used for the start_time of a line, else False.
 
         Returns:
             The output represents ``ms`` converted.

--- a/pyonfx/utils.py
+++ b/pyonfx/utils.py
@@ -258,7 +258,7 @@ class FrameUtility:
             >>>     fsc += FU.add(0, 100, 50)
             >>>     fsc += FU.add(100, 200, -50)
             >>>     print(f"Frame {i}/{n}: {s} - {e}; fsc: {fsc}")
-            >>> 
+            >>>
             >>> Frame 1/4: 25 - 75; fsc: 112.5
             >>> Frame 2/4: 75 - 125; fsc: 137.5
             >>> Frame 3/4: 125 - 175; fsc: 137.5

--- a/pyonfx/utils.py
+++ b/pyonfx/utils.py
@@ -59,7 +59,7 @@ class Utils:
     def accelerate(pct: float, accelerator: float) -> float:
         # Modifies pct according to the acceleration provided.
         # TODO: Implement acceleration based on bezier's curve
-        return pct ** accelerator
+        return pct**accelerator
 
     @staticmethod
     def interpolate(

--- a/pyonfx/utils.py
+++ b/pyonfx/utils.py
@@ -144,8 +144,8 @@ class FrameUtility:
     This class helps in the stressful calculation of frames per frame.
 
     Parameters:
-        start_time (positive float): Initial time
-        end_time (positive float): Final time
+        start_time_image (positive float): Initial time
+        end_time_image (positive float): Final time
         fps (positive Fraction, optional): Frame by second
 
     Returns:
@@ -165,7 +165,7 @@ class FrameUtility:
 
     """
 
-    def __init__(self, start_time: float, end_time: float, fps: Fraction = Fraction(24000, 1001)):
+    def __init__(self, start_time: int, end_time: int, fps: Fraction = Fraction(24000, 1001)):
         # Checking for invalid values
         if start_time < 0 or end_time < 0 or fps <= 0 or end_time < start_time:
             raise ValueError("Positive values and/or end_time > start_time expected.")

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from fractions import Fraction
 import pytest_check as check
 from pyonfx import *
 
@@ -12,7 +13,63 @@ io = Ass(path_ass)
 meta, styles, lines = io.get_data()
 
 # Config
+anime_fps = Fraction(24000, 1001)
 max_deviation = 3
+
+
+def test_ms_to_frames():
+    # All the outputs were checked with Aegisub DC 9214
+    # Test with dummy video
+    assert Convert.ms_to_frames(0, 1, True) == 0
+    assert Convert.ms_to_frames(0, 1, False) == -1
+    assert Convert.ms_to_frames(1, 1, True) == 1
+    assert Convert.ms_to_frames(1, 1, False) == 0
+
+    assert Convert.ms_to_frames(1000, 1, True) == 1
+    assert Convert.ms_to_frames(1001, 1, True) == 2
+    assert Convert.ms_to_frames(1000, 1, False) == 0
+    assert Convert.ms_to_frames(1001, 1, False) == 1
+
+    # Test with an anime video at 23.976 fps
+    assert Convert.ms_to_frames(0, anime_fps, True) == 0
+    assert Convert.ms_to_frames(0, anime_fps, False) == -1
+    assert Convert.ms_to_frames(20, anime_fps, True) == 1
+    assert Convert.ms_to_frames(60, anime_fps, False) == 1
+    assert Convert.ms_to_frames(41690, anime_fps, True) == 1000
+    assert Convert.ms_to_frames(41730, anime_fps, False) == 1000
+
+
+def test_frames_to_ms():
+    # All the outputs were checked with Aegisub DC 9214
+    # Test with dummy video
+    assert (
+        Convert.frames_to_ms(0, 1, True) == 0
+    )  # Should be -500, but negative ms don't exist
+    assert Convert.frames_to_ms(0, 1, False) == 500
+    assert Convert.frames_to_ms(1, 1, True) == 500
+    assert Convert.frames_to_ms(1, 1, False) == 1500
+
+    # Test with an anime video at 23.976 fps
+    assert Convert.frames_to_ms(0, anime_fps, True) == 0
+    assert Convert.frames_to_ms(0, anime_fps, False) == 21
+    assert Convert.frames_to_ms(1, anime_fps, True) == 21
+    assert Convert.frames_to_ms(1, anime_fps, False) == 63
+    assert Convert.frames_to_ms(1000, anime_fps, True) == 41687
+    assert Convert.frames_to_ms(1000, anime_fps, False) == 41729
+
+
+def test_move_ms_to_frame():
+    # All the outputs were checked with Aegisub DC 9214
+    # Test with dummy video
+    assert Convert.move_ms_to_frame(0, 1, True) == 0
+    assert Convert.move_ms_to_frame(96, 1, True) == 500
+    assert Convert.move_ms_to_frame(590, 1, True) == 500
+    assert Convert.move_ms_to_frame(1001, 1, True) == 1500
+
+    assert Convert.move_ms_to_frame(0, 1, False) == 0
+    assert Convert.move_ms_to_frame(96, 1, False) == 500
+    assert Convert.move_ms_to_frame(590, 1, False) == 500
+    assert Convert.move_ms_to_frame(1001, 1, False) == 1500
 
 
 def test_coloralpha():

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -133,15 +133,12 @@ def test_coloralpha():
     assert Convert.color(
         (0, 255 / 64, 255 / 64, 255), ColorModel.RGBA, ColorModel.HSV
     ) == (180, 100, 2)
-    assert (
-        Convert.color(
-            (0, 255 / 64, 255 / 64, 255),
-            ColorModel.RGBA,
-            ColorModel.HSV,
-            round_output=False,
-        )
-        == (180.0, 100.0, 1.5625)
-    )
+    assert Convert.color(
+        (0, 255 / 64, 255 / 64, 255),
+        ColorModel.RGBA,
+        ColorModel.HSV,
+        round_output=False,
+    ) == (180.0, 100.0, 1.5625)
 
     # -- Test color helper functions --
     # Test ass (bgr) -> rgb conversion

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -47,5 +47,5 @@ def test_frame_utility():
         fsc += FU.add(0, 100, 50)
         fsc += FU.add(100, 200, -50)
         fsc_values.append(fsc)
-    
+
     assert fsc_values == [112.5, 137.5, 137.5, 112.5]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import os
+from fractions import Fraction
 from pyonfx import *
 
 # Get ass path
@@ -9,26 +10,42 @@ path_ass = os.path.join(dir_path, "Ass", "in.ass")
 io = Ass(path_ass)
 meta, styles, lines = io.get_data()
 
+# Config
+anime_fps = Fraction(24000, 1001)
+
 
 def test_interpolation():
     res = Utils.interpolate(0.9, "&H000000&", "&HFFFFFF&")
     assert res == "&HE6E6E6&"
 
 
-def test_frames():
-    # print("\n")
-    FU = FrameUtility(0, 105, 40)
-    # print(FU.start_time)
-    for s, e, i, n in FU:
-        fsc = 100
-        fsc += FU.add(0, 50, 50)
-        fsc += FU.add(50, 100, -50)
-        # print(fsc, s, e, i, n)
+def test_frame_utility():
+    # All the outputs were checked with Aegisub DC 9214
+    FU = FrameUtility(0, 110, 20)
+    assert list(FU) == [(0, 25, 1, 3), (25, 75, 2, 3), (75, 125, 3, 3)]
 
-    # print("-----")
-    # print(FU.start_time)
+    FU = FrameUtility(0, 250, 20, 2)
+    assert list(FU) == [(0, 75, 1, 5), (75, 175, 3, 5), (175, 225, 5, 5)]
+
+    FU = FrameUtility(0, 250, 20, 3)
+    assert list(FU) == [(0, 125, 1, 5), (125, 225, 4, 5)]
+
+    FU = FrameUtility(424242, 424451, anime_fps)
+    assert list(FU) == [
+        (424236, 424278, 1, 5),
+        (424278, 424320, 2, 5),
+        (424320, 424361, 3, 5),
+        (424361, 424403, 4, 5),
+        (424403, 424445, 5, 5),
+    ]
+
+    # FU.add
+    FU = FrameUtility(25, 225, 20)
+    fsc_values = []
     for s, e, i, n in FU:
         fsc = 100
-        fsc += FU.add(0, 50, 50)
-        fsc += FU.add(50, 100, -50)
-        # print(fsc, s, e, i, n)
+        fsc += FU.add(0, 100, 50)
+        fsc += FU.add(100, 200, -50)
+        fsc_values.append(fsc)
+    
+    assert fsc_values == [112.5, 137.5, 137.5, 112.5]


### PR DESCRIPTION
The old version of FrameUtility did not work correctly. Now, it should always work.

This patch add 3 method in Convert.py (ms2frame, frame2ms and bound2frame) and a totally new version of FrameUtility.

Like you can see, at the line 81 of Convert.py, i add 0.011. I don't know why I have to do it, because I compared how pyonfx convert timestamp to ms (https://github.com/CoffeeStraw/PyonFX/blob/master/pyonfx/convert.py#L72) and aegisub (https://github.com/Ristellise/AegisubDC/blob/d4e6c9afef17953c2d62b874665a1bfb62949b32/libaegisub/ass/time.cpp#L29) and they gave the same ms. Maybe ffms2 don't index the frame the exact same way I do.

The bound2frame function is really usefull when you want to use FrameUtility with \t(). Like that, all the timing in the \t tag will be good

**Warning 1**:
I did not modify the **add function** of FrameUtility. It absolutely need to be modify by someone, because with the changes made, all the timing is now in frame (previously it was in ms), so there is no more fr.

**Warning 2**:
If you open a fake video with aegisub, this new FrameUtility will not work. I still don't know why, but aegisub does not index the fake video frame the same way that it index real video.

**Warning 3**:
This new version of FrameUtility still don't work with VFR (variable frame rate) video.

Example: `Convert.ms2frame(l.start_time, Fraction(24000/1001), "start")`

Thanks to Varde for his help!