### PR TITLE
Correction of FrameUtility V3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache Python
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
           key: ${{matrix.os}}-${{matrix.python-version}}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements.txt') }}
@@ -87,7 +87,7 @@ jobs:
         shell: pwsh
 
       - name: Cache Python
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
           key: ${{matrix.os}}-${{matrix.python-version}}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements.txt') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -54,7 +54,7 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       
       - name: Set up Python 3.12
         uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -110,7 +110,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Set up Python 3.12
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.12
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Cancelling pipeline (failed)
         if: failure()
-        uses: andymckay/cancel-action@0.2
+        uses: andymckay/cancel-action@0.5
 
       - name: Check formatting with black
         run: black --check .

--- a/README.md
+++ b/README.md
@@ -27,5 +27,6 @@ This project is licensed under the LGPL v3.0 License — see the [LICENSE](https
 
 * **[Youka](https://github.com/Youka)** for the original main functions ideas for **[NyuFX](https://github.com/Youka/NyuFX)**;
 * **[McWhite](https://github.com/BastianGanze)** for the original functions ideas of his library for **[NyuFX](https://github.com/Youka/NyuFX)**;
+* **[moi15moi](https://github.com/moi15moi)** for creating **[VideoTimestamps](https://github.com/moi15moi/VideoTimestamps)** and contributing significant improvements to the frame processing utilities;
 * **Siplas** for helping me out in the realization of the current logo for **PyonFX**;
 * **Preacer** for the name suggestion.

--- a/examples/2 - Beginner/2 - Utilities.py
+++ b/examples/2 - Beginner/2 - Utilities.py
@@ -44,7 +44,9 @@ def romaji(line, l):
         # Main Effect
         # Let's create a FrameUtility object and set up a radius for the random positions
         FU = FrameUtility(
-            line.start_time + syl.start_time, line.start_time + syl.end_time
+            line.start_time + syl.start_time,
+            line.start_time + syl.end_time,
+            io.input_timestamps,
         )
         radius = 2
 

--- a/examples/2 - Beginner/3 - Variants.py
+++ b/examples/2 - Beginner/3 - Variants.py
@@ -107,7 +107,11 @@ def romaji(line, l):
         # Jump-in to the first syl
         jump_height = 18
         if syl.i == 0:
-            FU = FrameUtility(line.start_time - line.leadin / 2, line.start_time)
+            FU = FrameUtility(
+                int(line.start_time - line.leadin / 2),
+                line.start_time,
+                io.input_timestamps,
+            )
             for s, e, i, n in FU:
                 l.start_time = s
                 l.end_time = e
@@ -133,7 +137,9 @@ def romaji(line, l):
             else syl.width
         )
         FU = FrameUtility(
-            line.start_time + syl.start_time, line.start_time + syl.end_time
+            line.start_time + syl.start_time,
+            line.start_time + syl.end_time,
+            io.input_timestamps,
         )
         for s, e, i, n in FU:
             l.start_time = s

--- a/examples/3 - Advanced/1 - WIP.py
+++ b/examples/3 - Advanced/1 - WIP.py
@@ -29,7 +29,9 @@ def romaji(line, l):
         l.layer = 1
 
         FU = FrameUtility(
-            line.start_time + syl.start_time, line.start_time + syl.end_time
+            line.start_time + syl.start_time,
+            line.start_time + syl.end_time,
+            io.input_timestamps,
         )
         rand = random.uniform(-10, 10)
 

--- a/pyonfx/__init__.py
+++ b/pyonfx/__init__.py
@@ -6,4 +6,4 @@ from .convert import Convert, ColorModel
 from .shape import Shape
 from .utils import Utils, FrameUtility, ColorUtility
 
-__version__ = "0.9.13"
+__version__ = "0.9.14"

--- a/pyonfx/convert.py
+++ b/pyonfx/convert.py
@@ -62,6 +62,9 @@ class Convert:
         """
         # Milliseconds?
         if type(ass_ms) is int and ass_ms >= 0:
+            # It round ms to cs. From https://github.com/Aegisub/Aegisub/blob/6f546951b4f004da16ce19ba638bf3eedefb9f31/libaegisub/include/libaegisub/ass/time.h#L32
+            # Ex: 49 ms to 50 ms
+            ass_ms = (ass_ms + 5) - (ass_ms + 5) % 10
 
             return "{:d}:{:02d}:{:02d}.{:02d}".format(
                 math.floor(ass_ms / 3600000) % 10,

--- a/pyonfx/convert.py
+++ b/pyonfx/convert.py
@@ -16,11 +16,10 @@
 # along with this program. If not, see http://www.gnu.org/licenses/.
 
 from __future__ import annotations
-import re
-import math
 import colorsys
+import math
+import re
 from enum import Enum
-from fractions import Fraction
 from typing import List, NamedTuple, Tuple, Union, TYPE_CHECKING
 
 from .font_utility import Font
@@ -80,79 +79,6 @@ class Convert:
             )
         else:
             raise ValueError("Milliseconds or ASS timestamp expected")
-
-    @staticmethod
-    def ms_to_frames(ms: int, fps: Union[int, float, Fraction], is_start: bool) -> int:
-        """Converts from milliseconds to frames.
-
-        Parameters:
-            ms (int): Milliseconds.
-            fps (positive int, float or Fraction): Frames per second.
-            is_start (bool): True if this time will be used for the start_time of a line, else False.
-
-        Returns:
-            The output represents ``ms`` converted.
-        """
-        # Logic taken from: https://github.com/Aegisub/Aegisub/blob/master/libaegisub/common/vfr.cpp#L205
-        if ms < 0:
-            raise ValueError("Parameter 'ms' must be an integer >= 0.")
-        if fps <= 0:
-            raise ValueError("Parameter 'fps' must be an integer > 0.")
-        # NOTE: a frame can be negative in Aegisub, so here we allow this possibility
-        return math.ceil((ms - 0.5) / 1000 * fps) - (0 if is_start else 1)
-
-    @staticmethod
-    def frames_to_ms(
-        frames: int, fps: Union[int, float, Fraction], is_start: bool
-    ) -> int:
-        """Converts from frames to milliseconds.
-
-        Parameters:
-            frames (int): Frames.
-            fps (positive int, float or Fraction): Frames per second.
-            is_start (bool): True if this time will be used for the start_time of a line, else False.
-
-        Returns:
-            The output represents ``frames`` converted.
-        """
-        # Logic taken from: https://github.com/Aegisub/Aegisub/blob/master/libaegisub/common/vfr.cpp#L233
-        if frames < 0:
-            raise ValueError("Parameter 'frames' must be an integer >= 0.")
-        if fps <= 0:
-            raise ValueError("Parameter 'fps' must be an integer > 0.")
-        # Since ms can't be negative, we have to handle frame 0 when converting frame value for a start time
-        if is_start and frames == 0:
-            return 0
-        curr_ms = frames * 1000 / fps
-        if is_start:
-            prev_ms = (frames - 1) * 1000 / fps
-            return math.floor(prev_ms + (curr_ms - prev_ms + 1) / 2)
-        else:
-            next_ms = (frames + 1) * 1000 / fps
-            return math.floor(curr_ms + (next_ms - curr_ms + 1) / 2)
-
-    @staticmethod
-    def move_ms_to_frame(
-        ms: int, fps: Union[int, float, Fraction], is_start: bool
-    ) -> int:
-        """
-        Moves the ms to when the corresponding frame starts or ends (depending on ``is_start``).
-        It is something close to using "CTRL + 3" and "CTRL + 4" on Aegisub 3.2.2.
-
-        Parameters:
-            ms (int): Milliseconds.
-            fps (positive int, float or Fraction): Frames per second.
-            is_start (bool): True if this time will be used for the start_time of a line, else False.
-
-        Returns:
-            The output represents ``ms`` converted.
-        """
-        # Since ms can't be negative, we have to handle frame 0 when converting frame value for a start time
-        if ms == 0:
-            return 0
-        return Convert.frames_to_ms(
-            Convert.ms_to_frames(ms, fps, is_start), fps, is_start
-        )
 
     @staticmethod
     def alpha_ass_to_dec(alpha_ass: str) -> int:

--- a/pyonfx/utils.py
+++ b/pyonfx/utils.py
@@ -248,19 +248,30 @@ class FrameUtility:
         end_value: float,
         accelerator: float = 1.0,
     ) -> float:
-        """
-        You can see this function as a \"\\t\" tag usable in frame per frame operations.
+        """The corresponding of the ``\\t`` tag in the frame per frame environment.
+
+        The ``\\t`` tag performs a transformation from one style to another.
+        This function is more primitive: it allows to perform a transformation from a numeric value to another.
+        Which can then be used in tags defining styles, thus achieving the same results of the ``\\t`` tag.
+
         It must be used inside a for loop which iterates a FrameUtility object.
 
         Parameters:
             start_time (int): Initial time.
             end_time (int): Final time.
-            end_value (int or float): Value reached at end_time.
+            end_value (int or float): Numeric value reached at end_time.
             accelerator (float): Accelerator value.
 
+        Returns:
+            The transformed numeric value at the current frame of this FrameUtility object.
+
         Examples:
-            >>> FU = FrameUtility(25, 225, 20)
+            >>> # Let's assume to have an Ass object named "io" having a 20 fps video (i.e. frames are 50 ms long)
+            >>> FU = FrameUtility(25, 225, io.input_timestamps)
             >>> for s, e, i, n in FU:
+            >>>     # We would like to transform the fsc value
+            >>>     # from 100 up 150 for the first 100 ms,
+            >>>     # and then from 150 to 100 for the remaining 200 ms
             >>>     fsc = 100
             >>>     fsc += FU.add(0, 100, 50)
             >>>     fsc += FU.add(100, 200, -50)

--- a/pyonfx/utils.py
+++ b/pyonfx/utils.py
@@ -209,9 +209,13 @@ class FrameUtility:
         self.start_ms = start_ms
         self.end_ms = end_ms
 
-        self.start_fr = self.curr_fr = timestamps.time_to_frame(start_ms, TimeType.START, 3)
+        self.start_fr = self.curr_fr = timestamps.time_to_frame(
+            start_ms, TimeType.START, 3
+        )
         self.end_fr = timestamps.time_to_frame(end_ms, TimeType.END, 3)
-        self.end_ms_snapped = timestamps.frame_to_time(self.end_fr, TimeType.END, 3, True)
+        self.end_ms_snapped = timestamps.frame_to_time(
+            self.end_fr, TimeType.END, 3, True
+        )
         self.n_fr = n_fr
         self.i = 0
         self.n = self.end_fr - self.start_fr + 1
@@ -222,7 +226,9 @@ class FrameUtility:
             yield (
                 self.timestamps.frame_to_time(self.curr_fr, TimeType.START, 3, True),
                 min(
-                    self.timestamps.frame_to_time(self.curr_fr + self.n_fr - 1, TimeType.END, 3, True),
+                    self.timestamps.frame_to_time(
+                        self.curr_fr + self.n_fr - 1, TimeType.END, 3, True
+                    ),
                     self.end_ms_snapped,
                 ),
                 self.i + 1,
@@ -282,7 +288,9 @@ class FrameUtility:
             >>> Frame 3/4: 125 - 175; fsc: 137.5
             >>> Frame 4/4: 175 - 225; fsc: 112.5
         """
-        curr_ms = self.timestamps.frame_to_time(self.i + (self.n_fr - 1) // 2, TimeType.END, 3, True)
+        curr_ms = self.timestamps.frame_to_time(
+            self.i + (self.n_fr - 1) // 2, TimeType.END, 3, True
+        )
 
         if curr_ms <= start_time:
             return 0

--- a/pyonfx/utils.py
+++ b/pyonfx/utils.py
@@ -177,11 +177,11 @@ class FrameUtility:
         - This ensures the subtitle will be visible for the entire frame duration
 
         Frame timings example:
-        Frame # : Start - End (Mid-point)
-        Frame 0:   0 -  25 (mid: 12.5)
-        Frame 1:  25 -  75 (mid: 50)
-        Frame 2:  75 - 125 (mid: 100)
-        Frame 3: 125 - 175 (mid: 150)
+        Frame #: Start - End (Player's seek time)
+        Frame 0:   0 -  25 (0, special case)
+        Frame 1:  25 -  75 (50)
+        Frame 2:  75 - 125 (100)
+        Frame 3: 125 - 175 (150)
         ...
 
         This approach:

--- a/pyonfx/utils.py
+++ b/pyonfx/utils.py
@@ -163,31 +163,31 @@ class FrameUtility:
         >>> Frame 3/3: 75 - 125
 
     Note:
-        In the following we try to cover at our best the knowledge behind FrameUtility.
+        Understanding FrameUtility:
 
-        Say we have an .mkv file containing a video file and a subtitle file.
-        When reproducing the .mkv in a player, a line is rendered on the current frame
-        if the current time of the player is in between the line's start and end time.
+        When playing a video with subtitles (e.g., an .mkv file):
+        - A subtitle line is displayed when the player's current time falls between the line's start and end times
+        - Videos can have either constant frame rates (CFR) or variable frame rates (VFR)
 
-        Depending on the video file, the frames' duration can either be constant (CFR) or
-        variable (VFR).
+        Example with a CFR video at 20 fps (50ms per frame):
+        - Player seeks frames at: 0ms, 50ms, 100ms, 150ms, ...
+        
+        When generating subtitle lines per frame, FrameUtility uses a "mid-point" approach:
+        - Each frame's timing is centered around the player's seek time
+        - This ensures the subtitle will be visible for the entire frame duration
+        
+        Frame timings example:
+        Frame # : Start - End (Mid-point)
+        Frame 0:   0 -  25 (mid: 12.5)
+        Frame 1:  25 -  75 (mid: 50)
+        Frame 2:  75 - 125 (mid: 100)
+        Frame 3: 125 - 175 (mid: 150)
+        ...
 
-        Let's now walk through an example.
-        Say we have a CFR video having fps = 20 (i.e. the individual frame duration = 50 ms).
-
-        The player will then seek for frames at the following times: 0, 50, 100, 150, ...
-
-        We now want to generate a subtitle line for each frame. Which start time and end time should we generate?
-        Based on the theory above, there are multiple answers to make our lines appear.
-
-        FrameUtility implements what should be the safest answer: it generates the start and end times such that
-        the mid time will always be the closest to the player's seek times. Therefore:
-        - FRAME NUMBER : START TIME - END TIME
-        - Frame 0: 0-25
-        - Frame 1: 25-75
-        - Frame 2: 75-125
-        - Frame 3: 125-175
-        - ...
+        This approach:
+        - Ensures smooth frame transitions
+        - Avoids flickering by avoiding gaps between frames
+        - Works reliably for both CFR and VFR videos
     """
 
     def __init__(
@@ -254,13 +254,15 @@ class FrameUtility:
         end_value: float,
         accelerator: float = 1.0,
     ) -> float:
-        """The corresponding of the ``\\t`` tag in the frame per frame environment.
+        """Frame-by-frame equivalent of the ASS ``\\t`` tag.
 
-        The ``\\t`` tag performs a transformation from one style to another.
-        This function is more primitive: it allows to perform a transformation from a numeric value to another.
-        Which can then be used in tags defining styles, thus achieving the same results of the ``\\t`` tag.
+        This function provides a frame-accurate way to transform numeric values over time,
+        similar to how the ASS ``\\t`` tag transforms styles. While ``\\t`` handles complete
+        style transformations, this method focuses on transforming individual numeric values
+        that can then be used within style tags.
 
-        It must be used inside a for loop which iterates a FrameUtility object.
+        Note:
+            Must be used within a for loop iterating a FrameUtility object.
 
         Parameters:
             start_time (int): Initial time.

--- a/pyonfx/utils.py
+++ b/pyonfx/utils.py
@@ -171,11 +171,11 @@ class FrameUtility:
 
         Example with a CFR video at 20 fps (50ms per frame):
         - Player seeks frames at: 0ms, 50ms, 100ms, 150ms, ...
-        
+
         When generating subtitle lines per frame, FrameUtility uses a "mid-point" approach:
         - Each frame's timing is centered around the player's seek time
         - This ensures the subtitle will be visible for the entire frame duration
-        
+
         Frame timings example:
         Frame # : Start - End (Mid-point)
         Frame 0:   0 -  25 (mid: 12.5)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "pywin32; platform_system=='Windows'",
     "pycairo; platform_system=='Linux' or platform_system=='Darwin'",
     "PyGObject; platform_system=='Linux' or platform_system=='Darwin'",
+    "VideoTimestamps>=0.1.1",
 ]
 classifiers=[
     "Development Status :: 4 - Beta",

--- a/tests/test_ass.py
+++ b/tests/test_ass.py
@@ -1,7 +1,9 @@
 import os
 import sys
 import pytest_check as check
+from fractions import Fraction
 from pyonfx import *
+from video_timestamps import FPSTimestamps, RoundingMethod
 
 # Get ass path used for tests
 dir_path = os.path.dirname(os.path.realpath(__file__))
@@ -124,3 +126,20 @@ def test_line_values():
     # Bold - Vertical Text
     check.almost_equal(lines[12].width, 31.546875, abs=max_deviation)
     check.almost_equal(lines[12].height, 396.0, abs=max_deviation)
+
+
+def test_ass_values():
+    check.is_true(os.path.samefile(io.path_input, path_ass))
+    check.equal(
+        os.path.realpath(io.path_output),
+        os.path.realpath(
+            os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), "Output.ass")
+        ),
+    )
+    # io.meta is tested in test_meta_values()
+    # io.styles is tested in test_line_values()
+    # io.lines is tested in test_line_values()
+    check.equal(
+        io.input_timestamps,
+        FPSTimestamps(RoundingMethod.ROUND, Fraction(1000), Fraction("23.976000")),
+    )

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -17,61 +17,6 @@ anime_fps = Fraction(24000, 1001)
 max_deviation = 3
 
 
-def test_ms_to_frames():
-    # All the outputs were checked with Aegisub DC 9214
-    # Test with dummy video
-    assert Convert.ms_to_frames(0, 1, True) == 0
-    assert Convert.ms_to_frames(0, 1, False) == -1
-    assert Convert.ms_to_frames(1, 1, True) == 1
-    assert Convert.ms_to_frames(1, 1, False) == 0
-
-    assert Convert.ms_to_frames(1000, 1, True) == 1
-    assert Convert.ms_to_frames(1001, 1, True) == 2
-    assert Convert.ms_to_frames(1000, 1, False) == 0
-    assert Convert.ms_to_frames(1001, 1, False) == 1
-
-    # Test with an anime video at 23.976 fps
-    assert Convert.ms_to_frames(0, anime_fps, True) == 0
-    assert Convert.ms_to_frames(0, anime_fps, False) == -1
-    assert Convert.ms_to_frames(20, anime_fps, True) == 1
-    assert Convert.ms_to_frames(60, anime_fps, False) == 1
-    assert Convert.ms_to_frames(41690, anime_fps, True) == 1000
-    assert Convert.ms_to_frames(41730, anime_fps, False) == 1000
-
-
-def test_frames_to_ms():
-    # All the outputs were checked with Aegisub DC 9214
-    # Test with dummy video
-    assert (
-        Convert.frames_to_ms(0, 1, True) == 0
-    )  # Should be -500, but negative ms don't exist
-    assert Convert.frames_to_ms(0, 1, False) == 500
-    assert Convert.frames_to_ms(1, 1, True) == 500
-    assert Convert.frames_to_ms(1, 1, False) == 1500
-
-    # Test with an anime video at 23.976 fps
-    assert Convert.frames_to_ms(0, anime_fps, True) == 0
-    assert Convert.frames_to_ms(0, anime_fps, False) == 21
-    assert Convert.frames_to_ms(1, anime_fps, True) == 21
-    assert Convert.frames_to_ms(1, anime_fps, False) == 63
-    assert Convert.frames_to_ms(1000, anime_fps, True) == 41687
-    assert Convert.frames_to_ms(1000, anime_fps, False) == 41729
-
-
-def test_move_ms_to_frame():
-    # All the outputs were checked with Aegisub DC 9214
-    # Test with dummy video
-    assert Convert.move_ms_to_frame(0, 1, True) == 0
-    assert Convert.move_ms_to_frame(96, 1, True) == 500
-    assert Convert.move_ms_to_frame(590, 1, True) == 500
-    assert Convert.move_ms_to_frame(1001, 1, True) == 1500
-
-    assert Convert.move_ms_to_frame(0, 1, False) == 0
-    assert Convert.move_ms_to_frame(96, 1, False) == 500
-    assert Convert.move_ms_to_frame(590, 1, False) == 500
-    assert Convert.move_ms_to_frame(1001, 1, False) == 1500
-
-
 def test_coloralpha():
     # -- Test alpha conversion functions --
     assert Convert.alpha_ass_to_dec("&HFF&") == 255

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import os
 from fractions import Fraction
 from pyonfx import *
+from video_timestamps import FPSTimestamps, RoundingMethod
 
 # Get ass path
 dir_path = os.path.dirname(os.path.realpath(__file__))
@@ -20,27 +21,29 @@ def test_interpolation():
 
 
 def test_frame_utility():
-    # All the outputs were checked with Aegisub DC 9214
-    FU = FrameUtility(0, 110, 20)
+    timestamps = FPSTimestamps(RoundingMethod.ROUND, Fraction(1000), Fraction(20))
+    FU = FrameUtility(0, 110, timestamps)
     assert list(FU) == [(0, 25, 1, 3), (25, 75, 2, 3), (75, 125, 3, 3)]
 
-    FU = FrameUtility(0, 250, 20, 2)
+    FU = FrameUtility(0, 250, timestamps, 2)
     assert list(FU) == [(0, 75, 1, 5), (75, 175, 3, 5), (175, 225, 5, 5)]
 
-    FU = FrameUtility(0, 250, 20, 3)
+    FU = FrameUtility(0, 250, timestamps, 3)
     assert list(FU) == [(0, 125, 1, 5), (125, 225, 4, 5)]
 
-    FU = FrameUtility(424242, 424451, anime_fps)
+    timestamps = FPSTimestamps(RoundingMethod.ROUND, Fraction(1000), anime_fps)
+    FU = FrameUtility(424242, 424451, timestamps)
     assert list(FU) == [
         (424236, 424278, 1, 5),
         (424278, 424320, 2, 5),
-        (424320, 424361, 3, 5),
-        (424361, 424403, 4, 5),
+        (424320, 424362, 3, 5),
+        (424362, 424403, 4, 5),
         (424403, 424445, 5, 5),
     ]
 
     # FU.add
-    FU = FrameUtility(25, 225, 20)
+    timestamps = FPSTimestamps(RoundingMethod.ROUND, Fraction(1000), Fraction(20))
+    FU = FrameUtility(25, 225, timestamps)
     fsc_values = []
     for s, e, i, n in FU:
         fsc = 100


### PR DESCRIPTION
Finally, this should be the last version of FrameUtility.
For reference, here are the previous version: #37, #46

### **Why it is needed?**
The previous FrameUtility would not work with VFR video, now yes.
Finally, the previous FrameUtility was more a hack than anything else.

### **What has been done**
- Add TimeType Enum
- Add [ffmpeg](https://www.ffmpeg.org/) dependency to get the video file timestamps
- Add [mkvtoolnix](https://mkvtoolnix.download/) dependency to get the video file timestamps for mkv file since it is more performant then ffmpeg
- Be able to create Timestamps from 3 methods (``from_fps``, ``from_video_file``, ``from_timestamps_file``)
- Correction how to convert ms to ass_timestamps (``Convert.time``)
- Update of the algorithm of ``Convert.ms_to_frames`` and ``Convert.frames_to_ms``
- Add many tests to be sure that we have the right behaviour
- Update ``FrameUtility`` to use the ``Timestamps`` class.
- Add proof for the algorith of ms_to_frames since it isn't intuitive.

### **What still need to be been done**
- Correct the github action workflow. I don't know why, but when I try to run it with act, the workflow blocks and stop doing anything
- Update the logic of ``FrameUtility.add`` to use ``Timestamps``. I don't understand what is the expected behaviour of this method.
- Update pyonfx version
- Pack ffmpeg with pyonfx. We could try to replicate [this method](https://github.com/CoffeeStraw/VVVVID-Downloader/blob/master/.github/workflows/ci.yml#L36-L50)