### PR TITLE
Fix the CI recently failing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest] # Disable macos-latest
         python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install libgirepository-2.0-dev gobject-introspection libcairo2-dev python3-dev build-essential python3-gi python3-gi-cairo
+          sudo apt-get install libgirepository-2.0-dev gobject-introspection libcairo2-dev python3-dev build-essential gir1.2-gtk-3.0 python3-gi python3-gi-cairo
       - name: Install platform-specific requirements (macOS) # Note: brew is very slow sometimes. TODO: speedup brew by using caching.
         if: matrix.os == 'macos-latest'
         run: brew install python py3cairo pygobject3 pango

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest] # Disable macos-latest
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
@@ -68,7 +68,7 @@ jobs:
           sudo apt-get install libgirepository-2.0-dev gobject-introspection libcairo2-dev python3-dev build-essential gir1.2-gtk-3.0 python3-gi python3-gi-cairo
       - name: Install platform-specific requirements (macOS) # Note: brew is very slow sometimes. TODO: speedup brew by using caching.
         if: matrix.os == 'macos-latest'
-        run: brew install python py3cairo pygobject3 pango
+        run: brew install python py3cairo pygobject3 pango cairo
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,10 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: brew install python py3cairo pygobject3 pango cairo glib
 
+      - name: Set DYLD_FALLBACK_LIBRARY_PATH for Homebrew (macOS)
+        if: matrix.os == 'macos-latest'
+        run: echo "DYLD_FALLBACK_LIBRARY_PATH=$(brew --prefix)/lib" >> $GITHUB_ENV
+
       - name: Setup Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install libgirepository-2.0-dev gobject-introspection libcairo2-dev python3-dev build-essential gir1.2-gtk-3.0 python3-gi python3-gi-cairo
-      - name: Install platform-specific requirements (macOS) # Note: brew is very slow sometimes. TODO: speedup brew by using caching.
+      - name: Install platform-specific requirements (macOS)
         if: matrix.os == 'macos-latest'
         run: brew install python py3cairo pygobject3 pango cairo glib
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install libgirepository-2.0-dev gobject-introspection python3-dev build-essential python3-gi python3-gi-cairo
+          sudo apt-get install libgirepository-2.0-dev gobject-introspection libcairo2-dev python3-dev build-essential python3-gi python3-gi-cairo
       - name: Install platform-specific requirements (macOS) # Note: brew is very slow sometimes. TODO: speedup brew by using caching.
         if: matrix.os == 'macos-latest'
         run: brew install python py3cairo pygobject3 pango

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0 python3-gi python3-gi-cairo
+          sudo apt-get install libgirepository-2.0-dev gobject-introspection python3-dev build-essential python3-gi python3-gi-cairo
       - name: Install platform-specific requirements (macOS) # Note: brew is very slow sometimes. TODO: speedup brew by using caching.
         if: matrix.os == 'macos-latest'
         run: brew install python py3cairo pygobject3 pango

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           sudo apt-get install libgirepository-2.0-dev gobject-introspection libcairo2-dev python3-dev build-essential gir1.2-gtk-3.0 python3-gi python3-gi-cairo
       - name: Install platform-specific requirements (macOS) # Note: brew is very slow sometimes. TODO: speedup brew by using caching.
         if: matrix.os == 'macos-latest'
-        run: brew install python py3cairo pygobject3 pango cairo
+        run: brew install python py3cairo pygobject3 pango cairo glib
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/docs/source/quick start.rst
+++ b/docs/source/quick start.rst
@@ -39,7 +39,7 @@ Installation
    .. code-block:: sh
       :emphasize-lines: 1,2
 
-      sudo apt install python3 python3-pip libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0 python3-gi python3-gi-cairo
+      sudo apt-get install libgirepository-2.0-dev gobject-introspection libcairo2-dev python3-dev build-essential gir1.2-gtk-3.0 python3-gi python3-gi-cairo
       python3 -m pip install --upgrade pyonfx
 
 .. dropdown:: Fedora
@@ -92,7 +92,7 @@ Installation
    .. code-block:: sh
       :emphasize-lines: 1,2
 
-      brew install python py3cairo pygobject3 pango
+      brew install python py3cairo pygobject3 pango cairo glib
       python3 -m pip install --upgrade pyonfx
 
    ⚠️Warning: If you experience output not rendered correctly, you might need to change the PangoCairo backend to fontconfig.


### PR DESCRIPTION
PyGObject updated its dependencies, and the CI recently started to fail (see: https://github.com/beeware/toga/issues/3143).
This PR fixes this behaviour.